### PR TITLE
feat: 当選確率の自動ローテーション機能を追加（30秒ごと）

### DIFF
--- a/garapon/lottery_test.go
+++ b/garapon/lottery_test.go
@@ -7,43 +7,48 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 // テスト間でグローバル状態をリセットするヘルパー
 func resetState() {
 	historyMu.Lock()
-	defer historyMu.Unlock()
 	history = nil
 	ticketCount = 0
+	historyMu.Unlock()
+
+	// 景品の重みを初期値に戻す
+	prizeMu.Lock()
+	prizes[0].Weight = 5
+	prizes[1].Weight = 30
+	prizes[2].Weight = 75
+	prizes[3].Weight = 190
+	prizes[4].Weight = 200
+	prizes[5].Weight = 500
+	lastRotatedAt = time.Time{}
+	nextRotateAt = time.Time{}
+	prizeMu.Unlock()
 }
 
 // ==============================
 // 抽選ロジックのテスト
 // ==============================
 
-// 抽選結果が有効な景品の等級であることを確認
 func TestDrawLottery_ReturnsValidPrize(t *testing.T) {
 	resetState()
 	result := drawLottery()
 
 	validGrades := map[PrizeGrade]bool{
-		GradeTokutou: true,
-		GradeIttou:   true,
-		GradeNittou:  true,
-		GradeSantou:  true,
-		GradeYontou:  true,
-		GradeHazure:  true,
+		GradeTokutou: true, GradeIttou: true, GradeNittou: true,
+		GradeSantou: true, GradeYontou: true, GradeHazure: true,
 	}
-
 	if !validGrades[result.Prize.Grade] {
 		t.Errorf("無効な等級が返された: %q", result.Prize.Grade)
 	}
 }
 
-// 抽選のたびにチケット番号が1ずつ増えることを確認
 func TestDrawLottery_IncrementTicketNum(t *testing.T) {
 	resetState()
-
 	r1 := drawLottery()
 	r2 := drawLottery()
 	r3 := drawLottery()
@@ -59,10 +64,8 @@ func TestDrawLottery_IncrementTicketNum(t *testing.T) {
 	}
 }
 
-// 抽選結果が履歴に正しく追加されることを確認
 func TestDrawLottery_AddsToHistory(t *testing.T) {
 	resetState()
-
 	drawLottery()
 	drawLottery()
 
@@ -75,10 +78,8 @@ func TestDrawLottery_AddsToHistory(t *testing.T) {
 	}
 }
 
-// 履歴は最新のものが先頭になることを確認
 func TestDrawLottery_HistoryIsRecentFirst(t *testing.T) {
 	resetState()
-
 	drawLottery() // ticket #1
 	drawLottery() // ticket #2
 
@@ -91,14 +92,11 @@ func TestDrawLottery_HistoryIsRecentFirst(t *testing.T) {
 	}
 }
 
-// 履歴の上限（50件）を超えないことを確認
 func TestDrawLottery_HistoryMaxSize(t *testing.T) {
 	resetState()
-
 	for i := 0; i < 60; i++ {
 		drawLottery()
 	}
-
 	historyMu.Lock()
 	count := len(history)
 	historyMu.Unlock()
@@ -108,20 +106,16 @@ func TestDrawLottery_HistoryMaxSize(t *testing.T) {
 	}
 }
 
-// 抽選結果のTimestampがゼロ値でないことを確認
 func TestDrawLottery_HasTimestamp(t *testing.T) {
 	resetState()
 	result := drawLottery()
-
 	if result.DrawnAt.IsZero() {
 		t.Error("DrawnAt がゼロ値になっている")
 	}
 }
 
-// 並列抽選でチケット番号が重複しないことを確認（並行安全性）
 func TestDrawLottery_ConcurrentSafe(t *testing.T) {
 	resetState()
-
 	const n = 100
 	var wg sync.WaitGroup
 	results := make([]DrawResult, n)
@@ -148,19 +142,24 @@ func TestDrawLottery_ConcurrentSafe(t *testing.T) {
 // 景品テーブルのテスト
 // ==============================
 
-// 景品テーブルの重みの合計が1000であることを確認
 func TestPrizesWeightSum(t *testing.T) {
+	resetState()
+	prizeMu.RLock()
 	total := 0
 	for _, p := range prizes {
 		total += p.Weight
 	}
+	prizeMu.RUnlock()
+
 	if total != 1000 {
 		t.Errorf("景品の重み合計: got %d, want 1000", total)
 	}
 }
 
-// すべての景品が必須フィールドを持つことを確認
 func TestPrizesHaveRequiredFields(t *testing.T) {
+	prizeMu.RLock()
+	defer prizeMu.RUnlock()
+
 	for _, p := range prizes {
 		if p.Grade == "" {
 			t.Errorf("Gradeが空の景品: %+v", p)
@@ -183,8 +182,10 @@ func TestPrizesHaveRequiredFields(t *testing.T) {
 	}
 }
 
-// 景品の等級がすべて異なることを確認（重複なし）
 func TestPrizesGradesAreUnique(t *testing.T) {
+	prizeMu.RLock()
+	defer prizeMu.RUnlock()
+
 	seen := make(map[PrizeGrade]bool)
 	for _, p := range prizes {
 		if seen[p.Grade] {
@@ -195,10 +196,117 @@ func TestPrizesGradesAreUnique(t *testing.T) {
 }
 
 // ==============================
+// 重みローテーションのテスト
+// ==============================
+
+// 生成された重みの合計が必ず 1000 であることを確認
+func TestGenerateNewWeights_SumIs1000(t *testing.T) {
+	for i := 0; i < 200; i++ {
+		weights := generateNewWeights()
+		total := 0
+		for _, w := range weights {
+			total += w
+		}
+		if total != 1000 {
+			t.Errorf("重み合計: got %d, want 1000 (試行 %d)", total, i)
+		}
+	}
+}
+
+// 生成された重みがすべて正の値であることを確認
+func TestGenerateNewWeights_AllPositive(t *testing.T) {
+	for i := 0; i < 200; i++ {
+		weights := generateNewWeights()
+		for j, w := range weights {
+			if w <= 0 {
+				t.Errorf("重み[%d]が0以下: %d (試行 %d)", j, w, i)
+			}
+		}
+	}
+}
+
+// 生成された重みの個数が景品数と一致することを確認
+func TestGenerateNewWeights_CountMatchesPrizes(t *testing.T) {
+	weights := generateNewWeights()
+	if len(weights) != len(prizes) {
+		t.Errorf("重みの個数: got %d, want %d", len(weights), len(prizes))
+	}
+}
+
+// rotatePrizes 後も重みの合計が 1000 であることを確認
+func TestRotatePrizes_SumStays1000(t *testing.T) {
+	resetState()
+	rotatePrizes()
+
+	prizeMu.RLock()
+	total := 0
+	for _, p := range prizes {
+		total += p.Weight
+	}
+	prizeMu.RUnlock()
+
+	if total != 1000 {
+		t.Errorf("ローテーション後の重み合計: got %d, want 1000", total)
+	}
+}
+
+// rotatePrizes が lastRotatedAt を更新することを確認
+func TestRotatePrizes_UpdatesLastRotatedAt(t *testing.T) {
+	resetState()
+	before := time.Now()
+	rotatePrizes()
+
+	prizeMu.RLock()
+	lra := lastRotatedAt
+	prizeMu.RUnlock()
+
+	if lra.Before(before) {
+		t.Errorf("lastRotatedAt が更新されていない: got %v, want >= %v", lra, before)
+	}
+}
+
+// rotatePrizes が nextRotateAt を rotationInterval 後に設定することを確認
+func TestRotatePrizes_UpdatesNextRotateAt(t *testing.T) {
+	resetState()
+	before := time.Now()
+	rotatePrizes()
+
+	prizeMu.RLock()
+	nra := nextRotateAt
+	lra := lastRotatedAt
+	prizeMu.RUnlock()
+
+	expectedMin := lra.Add(rotationInterval - time.Second)
+	expectedMax := before.Add(rotationInterval + time.Second)
+
+	if nra.Before(expectedMin) || nra.After(expectedMax) {
+		t.Errorf("nextRotateAt が期待範囲外: got %v", nra)
+	}
+}
+
+// rotatePrizes を複数回呼んでも重みの合計が常に 1000 であることを確認
+func TestRotatePrizes_MultipleRotations(t *testing.T) {
+	resetState()
+	for i := 0; i < 50; i++ {
+		rotatePrizes()
+
+		prizeMu.RLock()
+		total := 0
+		for _, p := range prizes {
+			total += p.Weight
+		}
+		prizeMu.RUnlock()
+
+		if total != 1000 {
+			t.Errorf("第%d回ローテーション後の重み合計: got %d, want 1000", i+1, total)
+		}
+	}
+}
+
+// ==============================
 // 統計のテスト
 // ==============================
 
-// 空の履歴の場合は TotalDraws=0 であることを確認
 func TestCalcStats_EmptyHistory(t *testing.T) {
 	resetState()
 	stats := calcStats()
@@ -211,7 +319,6 @@ func TestCalcStats_EmptyHistory(t *testing.T) {
 	}
 }
 
-// TotalDraws が実際の抽選回数と一致することを確認
 func TestCalcStats_TotalDraws(t *testing.T) {
 	resetState()
 	drawLottery()
@@ -224,30 +331,24 @@ func TestCalcStats_TotalDraws(t *testing.T) {
 	}
 }
 
-// GradeCount の合計が TotalDraws と一致することを確認
 func TestCalcStats_GradeCountSumEqualsTotalDraws(t *testing.T) {
 	resetState()
-
 	for i := 0; i < 10; i++ {
 		drawLottery()
 	}
-
 	stats := calcStats()
 	gradeTotal := 0
 	for _, cnt := range stats.GradeCount {
 		gradeTotal += cnt
 	}
-
 	if gradeTotal != stats.TotalDraws {
 		t.Errorf("GradeCount合計(%d) != TotalDraws(%d)", gradeTotal, stats.TotalDraws)
 	}
 }
 
-// LastUpdated がゼロ値でないことを確認
 func TestCalcStats_HasLastUpdated(t *testing.T) {
 	resetState()
 	stats := calcStats()
-
 	if stats.LastUpdated.IsZero() {
 		t.Error("LastUpdated がゼロ値になっている")
 	}
@@ -257,7 +358,6 @@ func TestCalcStats_HasLastUpdated(t *testing.T) {
 // HTTP ハンドラのテスト
 // ==============================
 
-// GET /api/draw は 405 を返すことを確認
 func TestApiDrawHandler_MethodNotAllowed(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/draw", nil)
 	w := httptest.NewRecorder()
@@ -268,7 +368,6 @@ func TestApiDrawHandler_MethodNotAllowed(t *testing.T) {
 	}
 }
 
-// POST /api/draw は有効な DrawResult を JSON で返すことを確認
 func TestApiDrawHandler_PostReturnsDrawResult(t *testing.T) {
 	resetState()
 	req := httptest.NewRequest(http.MethodPost, "/api/draw", nil)
@@ -281,7 +380,6 @@ func TestApiDrawHandler_PostReturnsDrawResult(t *testing.T) {
 	if ct := w.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
 		t.Errorf("Content-Type: got %q, want application/json", ct)
 	}
-
 	var result DrawResult
 	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
 		t.Fatalf("JSONパースエラー: %v", err)
@@ -294,7 +392,6 @@ func TestApiDrawHandler_PostReturnsDrawResult(t *testing.T) {
 	}
 }
 
-// GET /api/history は抽選履歴の JSON 配列を返すことを確認
 func TestApiHistoryHandler_ReturnsHistory(t *testing.T) {
 	resetState()
 	drawLottery()
@@ -307,7 +404,6 @@ func TestApiHistoryHandler_ReturnsHistory(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("ステータス: got %d, want %d", w.Code, http.StatusOK)
 	}
-
 	var hist []DrawResult
 	if err := json.Unmarshal(w.Body.Bytes(), &hist); err != nil {
 		t.Fatalf("JSONパースエラー: %v", err)
@@ -317,7 +413,6 @@ func TestApiHistoryHandler_ReturnsHistory(t *testing.T) {
 	}
 }
 
-// GET /api/stats は統計情報の JSON を返すことを確認
 func TestApiStatsHandler_ReturnsStats(t *testing.T) {
 	resetState()
 	drawLottery()
@@ -330,7 +425,6 @@ func TestApiStatsHandler_ReturnsStats(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("ステータス: got %d, want %d", w.Code, http.StatusOK)
 	}
-
 	var stats Stats
 	if err := json.Unmarshal(w.Body.Bytes(), &stats); err != nil {
 		t.Fatalf("JSONパースエラー: %v", err)
@@ -340,8 +434,11 @@ func TestApiStatsHandler_ReturnsStats(t *testing.T) {
 	}
 }
 
-// GET /api/prizes は全景品の JSON 配列を返すことを確認
-func TestApiPrizesHandler_ReturnsAllPrizes(t *testing.T) {
+// /api/prizes は PrizesInfo 形式（prizes 配列 + ローテーション情報）を返すことを確認
+func TestApiPrizesHandler_ReturnsPrizesInfo(t *testing.T) {
+	resetState()
+	nextRotateAt = time.Now().Add(rotationInterval)
+
 	req := httptest.NewRequest(http.MethodGet, "/api/prizes", nil)
 	w := httptest.NewRecorder()
 	apiPrizesHandler(w, req)
@@ -349,17 +446,41 @@ func TestApiPrizesHandler_ReturnsAllPrizes(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("ステータス: got %d, want %d", w.Code, http.StatusOK)
 	}
-
-	var ps []Prize
-	if err := json.Unmarshal(w.Body.Bytes(), &ps); err != nil {
+	var info PrizesInfo
+	if err := json.Unmarshal(w.Body.Bytes(), &info); err != nil {
 		t.Fatalf("JSONパースエラー: %v", err)
 	}
-	if len(ps) != len(prizes) {
-		t.Errorf("景品数: got %d, want %d", len(ps), len(prizes))
+	if len(info.Prizes) != len(prizes) {
+		t.Errorf("景品数: got %d, want %d", len(info.Prizes), len(prizes))
+	}
+	if info.RotationIntervalSec != int(rotationInterval.Seconds()) {
+		t.Errorf("RotationIntervalSec: got %d, want %d", info.RotationIntervalSec, int(rotationInterval.Seconds()))
+	}
+	if info.NextRotationAt.IsZero() {
+		t.Error("NextRotationAt がゼロ値")
 	}
 }
 
-// GET / は HTML を返すことを確認
+// /api/prizes が返す prizes の重み合計が 1000 であることを確認
+func TestApiPrizesHandler_WeightSumIs1000(t *testing.T) {
+	resetState()
+	req := httptest.NewRequest(http.MethodGet, "/api/prizes", nil)
+	w := httptest.NewRecorder()
+	apiPrizesHandler(w, req)
+
+	var info PrizesInfo
+	if err := json.Unmarshal(w.Body.Bytes(), &info); err != nil {
+		t.Fatalf("JSONパースエラー: %v", err)
+	}
+	total := 0
+	for _, p := range info.Prizes {
+		total += p.Weight
+	}
+	if total != 1000 {
+		t.Errorf("レスポンス内の重み合計: got %d, want 1000", total)
+	}
+}
+
 func TestHomeHandler_ReturnsHTML(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
@@ -371,12 +492,14 @@ func TestHomeHandler_ReturnsHTML(t *testing.T) {
 	if ct := w.Header().Get("Content-Type"); !strings.Contains(ct, "text/html") {
 		t.Errorf("Content-Type: got %q, want text/html", ct)
 	}
-
 	body := w.Body.String()
 	if !strings.Contains(body, "<!DOCTYPE html>") {
 		t.Error("レスポンスに <!DOCTYPE html> が含まれていない")
 	}
 	if !strings.Contains(body, "ガラガラポン") {
 		t.Error("レスポンスに 'ガラガラポン' が含まれていない")
+	}
+	if !strings.Contains(body, "countdown") {
+		t.Error("レスポンスにカウントダウン要素が含まれていない")
 	}
 }

--- a/garapon/main.go
+++ b/garapon/main.go
@@ -14,12 +14,12 @@ import (
 type PrizeGrade string
 
 const (
-	GradeTokutou  PrizeGrade = "特等"
-	GradeIttou    PrizeGrade = "1等"
-	GradeNittou   PrizeGrade = "2等"
-	GradeSantou   PrizeGrade = "3等"
-	GradeYontou   PrizeGrade = "4等"
-	GradeHazure   PrizeGrade = "参加賞"
+	GradeTokutou PrizeGrade = "特等"
+	GradeIttou   PrizeGrade = "1等"
+	GradeNittou  PrizeGrade = "2等"
+	GradeSantou  PrizeGrade = "3等"
+	GradeYontou  PrizeGrade = "4等"
+	GradeHazure  PrizeGrade = "参加賞"
 )
 
 // ボールの色
@@ -34,7 +34,7 @@ type Prize struct {
 	Name        string     `json:"name"`
 	Description string     `json:"description"`
 	Ball        BallColor  `json:"ball"`
-	Weight      int        `json:"weight"` // 抽選の重み（合計1000）
+	Weight      int        `json:"weight"`
 }
 
 // 抽選結果
@@ -51,69 +51,133 @@ type Stats struct {
 	LastUpdated time.Time      `json:"last_updated"`
 }
 
-// 景品テーブル（重みの合計 = 1000）
+// 景品一覧レスポンス（ローテーション情報付き）
+type PrizesInfo struct {
+	Prizes              []Prize   `json:"prizes"`
+	NextRotationAt      time.Time `json:"next_rotation_at"`
+	LastRotatedAt       time.Time `json:"last_rotated_at"`
+	RotationIntervalSec int       `json:"rotation_interval_sec"`
+}
+
+// ローテーション間隔
+const rotationInterval = 30 * time.Second
+
+// 各景品（参加賞を除く）の重みの範囲 [min, max]
+// 参加賞 は 1000 - 他の合計 で自動計算
+// Max合計 = 15+60+120+250+300 = 745 → 参加賞 min = 255
+// Min合計 = 1+10+30+80+100  = 221 → 参加賞 max = 779
+var weightBounds = [][2]int{
+	{1, 15},    // 特等
+	{10, 60},   // 1等
+	{30, 120},  // 2等
+	{80, 250},  // 3等
+	{100, 300}, // 4等
+}
+
+// 景品テーブル（prizeMu で保護）
 var prizes = []Prize{
 	{
 		Grade:       GradeTokutou,
 		Name:        "特等賞",
 		Description: "豪華旅行券 ¥100,000",
 		Ball:        BallColor{Name: "金色", Hex: "#FFD700"},
-		Weight:      5, // 0.5%
+		Weight:      5,
 	},
 	{
 		Grade:       GradeIttou,
 		Name:        "1等賞",
 		Description: "商品券 ¥10,000",
 		Ball:        BallColor{Name: "赤", Hex: "#FF3333"},
-		Weight:      30, // 3%
+		Weight:      30,
 	},
 	{
 		Grade:       GradeNittou,
 		Name:        "2等賞",
 		Description: "商品券 ¥5,000",
 		Ball:        BallColor{Name: "青", Hex: "#3366FF"},
-		Weight:      75, // 7.5%
+		Weight:      75,
 	},
 	{
 		Grade:       GradeSantou,
 		Name:        "3等賞",
 		Description: "商品券 ¥1,000",
 		Ball:        BallColor{Name: "緑", Hex: "#33AA33"},
-		Weight:      190, // 19%
+		Weight:      190,
 	},
 	{
 		Grade:       GradeYontou,
 		Name:        "4等賞",
 		Description: "お買い物割引券 ¥500",
 		Ball:        BallColor{Name: "黄色", Hex: "#FFCC00"},
-		Weight:      200, // 20%
+		Weight:      200,
 	},
 	{
 		Grade:       GradeHazure,
 		Name:        "参加賞",
 		Description: "記念品プレゼント",
 		Ball:        BallColor{Name: "白", Hex: "#F0F0F0"},
-		Weight:      500, // 50%
+		Weight:      500,
 	},
 }
 
 var (
+	prizeMu       sync.RWMutex
+	nextRotateAt  time.Time
+	lastRotatedAt time.Time
+
 	history     []DrawResult
 	historyMu   sync.Mutex
 	ticketCount int
 )
 
+// 新しい重みセットをランダム生成（合計は必ず 1000）
+func generateNewWeights() []int {
+	weights := make([]int, len(prizes))
+	total := 0
+	for i, b := range weightBounds {
+		w := b[0] + rand.IntN(b[1]-b[0]+1)
+		weights[i] = w
+		total += w
+	}
+	weights[len(prizes)-1] = 1000 - total // 参加賞
+	return weights
+}
+
+// 景品の重みをローテーション
+func rotatePrizes() {
+	weights := generateNewWeights()
+
+	prizeMu.Lock()
+	for i := range prizes {
+		prizes[i].Weight = weights[i]
+	}
+	lastRotatedAt = time.Now()
+	nextRotateAt = lastRotatedAt.Add(rotationInterval)
+	prizeMu.Unlock()
+}
+
+// バックグラウンドでローテーションを開始
+func startPrizeRotation() {
+	nextRotateAt = time.Now().Add(rotationInterval)
+	go func() {
+		ticker := time.NewTicker(rotationInterval)
+		defer ticker.Stop()
+		for range ticker.C {
+			rotatePrizes()
+		}
+	}()
+}
+
 // 抽選を行う
 func drawLottery() DrawResult {
+	prizeMu.RLock()
 	total := 0
 	for _, p := range prizes {
 		total += p.Weight
 	}
-
 	n := rand.IntN(total)
 	cumulative := 0
 	selected := prizes[len(prizes)-1]
-
 	for _, p := range prizes {
 		cumulative += p.Weight
 		if n < cumulative {
@@ -121,6 +185,7 @@ func drawLottery() DrawResult {
 			break
 		}
 	}
+	prizeMu.RUnlock()
 
 	historyMu.Lock()
 	ticketCount++
@@ -152,7 +217,6 @@ func calcStats() Stats {
 	for _, r := range history {
 		counts[string(r.Prize.Grade)]++
 	}
-
 	return Stats{
 		TotalDraws:  len(history),
 		GradeCount:  counts,
@@ -170,7 +234,6 @@ func homeHandler(w http.ResponseWriter, r *http.Request) {
     <title>🎰 商店街ガラガラポン抽選会</title>
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
-
         body {
             font-family: 'Hiragino Kaku Gothic Pro', 'Meiryo', sans-serif;
             background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
@@ -178,13 +241,11 @@ func homeHandler(w http.ResponseWriter, r *http.Request) {
             color: white;
             overflow-x: hidden;
         }
-
         .header {
             text-align: center;
             padding: 30px 20px 10px;
             background: linear-gradient(180deg, rgba(255,200,0,0.15) 0%, transparent 100%);
         }
-
         .header h1 {
             font-size: 2.5em;
             color: #FFD700;
@@ -192,12 +253,7 @@ func homeHandler(w http.ResponseWriter, r *http.Request) {
             margin-bottom: 8px;
             letter-spacing: 3px;
         }
-
-        .header p {
-            color: #aaa;
-            font-size: 1em;
-        }
-
+        .header p { color: #aaa; font-size: 1em; }
         .main-content {
             display: flex;
             flex-wrap: wrap;
@@ -207,451 +263,163 @@ func homeHandler(w http.ResponseWriter, r *http.Request) {
             margin: 0 auto;
             justify-content: center;
         }
-
-        /* ガラガラポンマシン */
-        .machine-section {
-            flex: 0 0 auto;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-        }
-
-        .machine-wrapper {
-            position: relative;
-            width: 320px;
-        }
-
-        /* ドラム本体 */
-        .drum-container {
-            position: relative;
-            width: 280px;
-            height: 280px;
-            margin: 0 auto;
-        }
-
+        .machine-section { flex: 0 0 auto; display: flex; flex-direction: column; align-items: center; }
+        .machine-wrapper { position: relative; width: 320px; }
+        .drum-container { position: relative; width: 280px; height: 280px; margin: 0 auto; }
         .drum {
-            width: 100%;
-            height: 100%;
-            border-radius: 50%;
+            width: 100%; height: 100%; border-radius: 50%;
             background: radial-gradient(circle at 35% 35%, #888, #444 60%, #222);
             border: 8px solid #666;
-            box-shadow:
-                0 0 0 4px #888,
-                0 0 30px rgba(0,0,0,0.8),
-                inset 0 0 40px rgba(0,0,0,0.5);
-            position: relative;
-            overflow: hidden;
-            transition: transform 0.1s;
+            box-shadow: 0 0 0 4px #888, 0 0 30px rgba(0,0,0,0.8), inset 0 0 40px rgba(0,0,0,0.5);
+            position: relative; overflow: hidden; transition: transform 0.1s;
         }
-
-        .drum.spinning {
-            animation: drumSpin 0.2s linear infinite;
-        }
-
-        @keyframes drumSpin {
-            from { transform: rotate(0deg); }
-            to { transform: rotate(360deg); }
-        }
-
-        /* ドラム内の格子模様 */
+        .drum.spinning { animation: drumSpin 0.2s linear infinite; }
+        @keyframes drumSpin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
         .drum-grid {
-            position: absolute;
-            inset: 10px;
-            border-radius: 50%;
+            position: absolute; inset: 10px; border-radius: 50%;
             background:
-                repeating-linear-gradient(
-                    0deg,
-                    transparent,
-                    transparent 18px,
-                    rgba(255,255,255,0.08) 18px,
-                    rgba(255,255,255,0.08) 19px
-                ),
-                repeating-linear-gradient(
-                    90deg,
-                    transparent,
-                    transparent 18px,
-                    rgba(255,255,255,0.08) 18px,
-                    rgba(255,255,255,0.08) 19px
-                );
+                repeating-linear-gradient(0deg, transparent, transparent 18px, rgba(255,255,255,0.08) 18px, rgba(255,255,255,0.08) 19px),
+                repeating-linear-gradient(90deg, transparent, transparent 18px, rgba(255,255,255,0.08) 18px, rgba(255,255,255,0.08) 19px);
         }
-
-        /* ドラム内のボール群 */
-        .drum-balls {
-            position: absolute;
-            inset: 20px;
-            border-radius: 50%;
-            overflow: hidden;
-        }
-
+        .drum-balls { position: absolute; inset: 20px; border-radius: 50%; overflow: hidden; }
         .mini-ball {
-            position: absolute;
-            width: 28px;
-            height: 28px;
-            border-radius: 50%;
+            position: absolute; width: 28px; height: 28px; border-radius: 50%;
             box-shadow: inset -3px -3px 6px rgba(0,0,0,0.4), inset 2px 2px 4px rgba(255,255,255,0.3);
         }
-
-        /* ハンドル */
-        .handle-area {
-            display: flex;
-            justify-content: flex-end;
-            margin-top: -40px;
-            padding-right: 10px;
-        }
-
-        .handle {
-            width: 60px;
-            height: 120px;
-            position: relative;
-        }
-
+        .handle-area { display: flex; justify-content: flex-end; margin-top: -40px; padding-right: 10px; }
+        .handle { width: 60px; height: 120px; position: relative; }
         .handle-bar {
-            width: 12px;
-            height: 80px;
+            width: 12px; height: 80px;
             background: linear-gradient(90deg, #888, #ccc, #888);
-            border-radius: 6px;
-            margin: 0 auto;
-            box-shadow: 2px 2px 6px rgba(0,0,0,0.5);
+            border-radius: 6px; margin: 0 auto; box-shadow: 2px 2px 6px rgba(0,0,0,0.5);
         }
-
         .handle-knob {
-            width: 36px;
-            height: 36px;
-            border-radius: 50%;
+            width: 36px; height: 36px; border-radius: 50%;
             background: radial-gradient(circle at 35% 35%, #ffcc00, #cc8800);
-            border: 3px solid #aa6600;
-            margin: 0 auto;
+            border: 3px solid #aa6600; margin: 0 auto;
             box-shadow: 0 4px 8px rgba(0,0,0,0.5);
-            cursor: pointer;
-            transition: transform 0.1s;
+            cursor: pointer; transition: transform 0.1s;
         }
-
-        .handle-knob:hover {
-            transform: scale(1.1);
-        }
-
-        .handle-knob:active {
-            transform: scale(0.95);
-        }
-
-        /* ボール排出口 */
+        .handle-knob:hover { transform: scale(1.1); }
+        .handle-knob:active { transform: scale(0.95); }
         .outlet {
-            width: 100px;
-            height: 50px;
-            margin: 10px auto 0;
+            width: 100px; height: 50px; margin: 10px auto 0;
             background: linear-gradient(180deg, #333, #555);
-            border-radius: 0 0 20px 20px;
-            border: 4px solid #666;
-            border-top: none;
-            position: relative;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            overflow: visible;
+            border-radius: 0 0 20px 20px; border: 4px solid #666; border-top: none;
+            position: relative; display: flex; align-items: center; justify-content: center; overflow: visible;
         }
-
-        .outlet-label {
-            font-size: 0.7em;
-            color: #aaa;
-            letter-spacing: 1px;
-        }
-
-        /* 排出されるボール */
+        .outlet-label { font-size: 0.7em; color: #aaa; letter-spacing: 1px; }
         .result-ball {
-            width: 80px;
-            height: 80px;
-            border-radius: 50%;
-            position: absolute;
-            top: -120px;
-            left: 50%;
-            transform: translateX(-50%);
-            box-shadow:
-                inset -8px -8px 15px rgba(0,0,0,0.4),
-                inset 4px 4px 10px rgba(255,255,255,0.4),
-                0 8px 20px rgba(0,0,0,0.5);
-            display: none;
-            animation: ballDrop 0.6s ease-out forwards;
+            width: 80px; height: 80px; border-radius: 50%;
+            position: absolute; top: -120px; left: 50%; transform: translateX(-50%);
+            box-shadow: inset -8px -8px 15px rgba(0,0,0,0.4), inset 4px 4px 10px rgba(255,255,255,0.4), 0 8px 20px rgba(0,0,0,0.5);
+            display: none; animation: ballDrop 0.6s ease-out forwards;
         }
-
         @keyframes ballDrop {
-            0% { top: -140px; opacity: 0; transform: translateX(-50%) scale(0.5); }
-            50% { top: -100px; opacity: 1; transform: translateX(-50%) scale(1.1); }
+            0%   { top: -140px; opacity: 0; transform: translateX(-50%) scale(0.5); }
+            50%  { top: -100px; opacity: 1; transform: translateX(-50%) scale(1.1); }
             100% { top: -110px; opacity: 1; transform: translateX(-50%) scale(1); }
         }
-
-        .result-ball.show {
-            display: block;
-        }
-
-        /* 台座 */
+        .result-ball.show { display: block; }
         .machine-base {
-            width: 300px;
-            height: 20px;
+            width: 300px; height: 20px;
             background: linear-gradient(180deg, #888, #555);
-            border-radius: 0 0 10px 10px;
-            margin: 0 auto;
-            box-shadow: 0 6px 12px rgba(0,0,0,0.5);
+            border-radius: 0 0 10px 10px; margin: 0 auto; box-shadow: 0 6px 12px rgba(0,0,0,0.5);
         }
-
-        /* 抽選ボタン */
         .draw-btn {
-            margin-top: 30px;
-            padding: 18px 60px;
-            font-size: 1.4em;
-            font-weight: bold;
-            background: linear-gradient(135deg, #FFD700, #FF8C00);
-            color: #1a1a1a;
-            border: none;
-            border-radius: 50px;
-            cursor: pointer;
-            box-shadow: 0 6px 20px rgba(255,140,0,0.5);
-            transition: all 0.2s;
-            letter-spacing: 2px;
+            margin-top: 30px; padding: 18px 60px; font-size: 1.4em; font-weight: bold;
+            background: linear-gradient(135deg, #FFD700, #FF8C00); color: #1a1a1a;
+            border: none; border-radius: 50px; cursor: pointer;
+            box-shadow: 0 6px 20px rgba(255,140,0,0.5); transition: all 0.2s; letter-spacing: 2px;
         }
-
-        .draw-btn:hover:not(:disabled) {
-            transform: translateY(-3px);
-            box-shadow: 0 10px 30px rgba(255,140,0,0.7);
-        }
-
-        .draw-btn:active:not(:disabled) {
-            transform: translateY(0);
-        }
-
-        .draw-btn:disabled {
-            opacity: 0.6;
-            cursor: not-allowed;
-        }
-
-        /* 結果表示パネル */
-        .result-section {
-            flex: 1;
-            min-width: 300px;
-        }
-
+        .draw-btn:hover:not(:disabled) { transform: translateY(-3px); box-shadow: 0 10px 30px rgba(255,140,0,0.7); }
+        .draw-btn:active:not(:disabled) { transform: translateY(0); }
+        .draw-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+        .result-section { flex: 1; min-width: 300px; }
         .result-panel {
-            background: rgba(255,255,255,0.05);
-            border: 1px solid rgba(255,255,255,0.1);
-            border-radius: 20px;
-            padding: 30px;
-            margin-bottom: 20px;
-            min-height: 200px;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-            text-align: center;
-            transition: all 0.3s;
+            background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.1);
+            border-radius: 20px; padding: 30px; margin-bottom: 20px; min-height: 200px;
+            display: flex; flex-direction: column; align-items: center; justify-content: center;
+            text-align: center; transition: all 0.3s;
         }
-
         .result-panel.highlight {
-            border-color: rgba(255,215,0,0.5);
-            background: rgba(255,215,0,0.05);
+            border-color: rgba(255,215,0,0.5); background: rgba(255,215,0,0.05);
             box-shadow: 0 0 30px rgba(255,215,0,0.2);
         }
-
         .result-grade {
-            font-size: 3em;
-            font-weight: bold;
-            margin-bottom: 10px;
-            opacity: 0;
-            transform: scale(0.5);
+            font-size: 3em; font-weight: bold; margin-bottom: 10px;
+            opacity: 0; transform: scale(0.5);
             transition: all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
         }
-
-        .result-grade.show {
-            opacity: 1;
-            transform: scale(1);
-        }
-
-        .result-name {
-            font-size: 1.4em;
-            color: #ddd;
-            margin-bottom: 8px;
-        }
-
-        .result-desc {
-            font-size: 1.1em;
-            color: #aaa;
-        }
-
-        .wait-msg {
-            color: #555;
-            font-size: 1.1em;
-        }
-
-        /* 景品表 */
+        .result-grade.show { opacity: 1; transform: scale(1); }
+        .result-name { font-size: 1.4em; color: #ddd; margin-bottom: 8px; }
+        .result-desc { font-size: 1.1em; color: #aaa; }
+        .wait-msg { color: #555; font-size: 1.1em; }
         .prize-table-section {
-            background: rgba(255,255,255,0.05);
-            border: 1px solid rgba(255,255,255,0.1);
-            border-radius: 20px;
-            padding: 25px;
-            margin-bottom: 20px;
+            background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.1);
+            border-radius: 20px; padding: 25px; margin-bottom: 20px;
+            transition: background 0.5s;
         }
-
-        .prize-table-section h2 {
-            color: #FFD700;
-            margin-bottom: 15px;
-            font-size: 1.2em;
-            letter-spacing: 2px;
+        .prize-table-section.flash {
+            background: rgba(255,215,0,0.1);
         }
-
+        .prize-table-header {
+            display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px;
+        }
+        .prize-table-header h2 { color: #FFD700; font-size: 1.2em; letter-spacing: 2px; }
+        .live-badge {
+            font-size: 0.65em; background: #cc2200; color: white;
+            padding: 2px 7px; border-radius: 4px; letter-spacing: 1px;
+            animation: livePulse 1.2s ease-in-out infinite;
+        }
+        @keyframes livePulse { 0%,100%{opacity:1;} 50%{opacity:0.4;} }
+        .rotation-timer {
+            font-size: 0.82em; color: #888; margin-bottom: 12px;
+            display: flex; align-items: center; gap: 6px;
+        }
+        .countdown-num {
+            color: #FFD700; font-weight: bold; font-size: 1.15em;
+            min-width: 24px; display: inline-block; text-align: center;
+        }
+        .countdown-num.soon { color: #FF6644; animation: urgentPulse 0.5s ease-in-out infinite; }
+        @keyframes urgentPulse { 0%,100%{transform:scale(1);} 50%{transform:scale(1.2);} }
         .prize-row {
-            display: flex;
-            align-items: center;
-            gap: 12px;
-            padding: 8px 0;
+            display: flex; align-items: center; gap: 12px; padding: 8px 0;
             border-bottom: 1px solid rgba(255,255,255,0.05);
         }
-
         .prize-row:last-child { border-bottom: none; }
-
         .ball-icon {
-            width: 24px;
-            height: 24px;
-            border-radius: 50%;
-            flex-shrink: 0;
+            width: 24px; height: 24px; border-radius: 50%; flex-shrink: 0;
             box-shadow: inset -2px -2px 4px rgba(0,0,0,0.4), inset 1px 1px 3px rgba(255,255,255,0.3);
         }
-
-        .prize-grade-label {
-            font-weight: bold;
-            min-width: 50px;
-            font-size: 0.95em;
-        }
-
-        .prize-prize-name {
-            color: #ddd;
-            flex: 1;
-            font-size: 0.9em;
-        }
-
-        .prize-prob {
-            color: #888;
-            font-size: 0.8em;
-        }
-
-        /* 履歴 */
+        .prize-grade-label { font-weight: bold; min-width: 50px; font-size: 0.95em; }
+        .prize-prize-name { color: #ddd; flex: 1; font-size: 0.9em; }
+        .prize-prob { color: #888; font-size: 0.8em; min-width: 50px; text-align: right; }
         .history-section {
-            background: rgba(255,255,255,0.05);
-            border: 1px solid rgba(255,255,255,0.1);
-            border-radius: 20px;
-            padding: 25px;
+            background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.1);
+            border-radius: 20px; padding: 25px;
         }
-
-        .history-section h2 {
-            color: #FFD700;
-            margin-bottom: 15px;
-            font-size: 1.2em;
-            letter-spacing: 2px;
-        }
-
-        #history-list {
-            max-height: 300px;
-            overflow-y: auto;
-        }
-
+        .history-section h2 { color: #FFD700; margin-bottom: 15px; font-size: 1.2em; letter-spacing: 2px; }
+        #history-list { max-height: 300px; overflow-y: auto; }
         .history-item {
-            display: flex;
-            align-items: center;
-            gap: 10px;
-            padding: 8px 0;
+            display: flex; align-items: center; gap: 10px; padding: 8px 0;
             border-bottom: 1px solid rgba(255,255,255,0.05);
             animation: fadeIn 0.3s ease;
         }
-
-        @keyframes fadeIn {
-            from { opacity: 0; transform: translateY(-10px); }
-            to { opacity: 1; transform: translateY(0); }
-        }
-
-        .history-num {
-            color: #666;
-            font-size: 0.8em;
-            min-width: 40px;
-        }
-
-        .history-grade {
-            font-weight: bold;
-            font-size: 0.9em;
-            min-width: 60px;
-        }
-
-        .history-prize {
-            color: #aaa;
-            font-size: 0.85em;
-            flex: 1;
-        }
-
-        .history-time {
-            color: #555;
-            font-size: 0.75em;
-        }
-
-        /* 統計 */
-        .stats-bar {
-            display: flex;
-            gap: 15px;
-            flex-wrap: wrap;
-            margin-top: 15px;
-            justify-content: center;
-        }
-
-        .stat-chip {
-            background: rgba(255,255,255,0.08);
-            padding: 6px 14px;
-            border-radius: 20px;
-            font-size: 0.85em;
-            color: #ccc;
-        }
-
-        .stat-chip span {
-            color: #FFD700;
-            font-weight: bold;
-        }
-
-        /* 紙吹雪 */
-        .confetti-container {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            pointer-events: none;
-            z-index: 1000;
-        }
-
-        .confetti-piece {
-            position: absolute;
-            width: 10px;
-            height: 10px;
-            top: -20px;
-            animation: confettiFall linear forwards;
-        }
-
-        @keyframes confettiFall {
-            to {
-                top: 110vh;
-                transform: rotate(720deg);
-            }
-        }
-
-        /* 等賞カラーマッピング */
-        .grade-tokutou { color: #FFD700; }
-        .grade-ittou   { color: #FF6666; }
-        .grade-nittou  { color: #6699FF; }
-        .grade-santou  { color: #66CC66; }
-        .grade-yontou  { color: #FFDD44; }
-        .grade-hazure  { color: #AAAAAA; }
-
-        .no-history {
-            color: #555;
-            font-size: 0.9em;
-            text-align: center;
-            padding: 20px 0;
-        }
-
-        /* レスポンシブ */
+        @keyframes fadeIn { from{opacity:0;transform:translateY(-10px);} to{opacity:1;transform:translateY(0);} }
+        .history-num { color: #666; font-size: 0.8em; min-width: 40px; }
+        .history-grade { font-weight: bold; font-size: 0.9em; min-width: 60px; }
+        .history-prize { color: #aaa; font-size: 0.85em; flex: 1; }
+        .history-time { color: #555; font-size: 0.75em; }
+        .stats-bar { display: flex; gap: 15px; flex-wrap: wrap; margin-top: 15px; justify-content: center; }
+        .stat-chip { background: rgba(255,255,255,0.08); padding: 6px 14px; border-radius: 20px; font-size: 0.85em; color: #ccc; }
+        .stat-chip span { color: #FFD700; font-weight: bold; }
+        .confetti-container { position: fixed; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none; z-index: 1000; }
+        .confetti-piece { position: absolute; width: 10px; height: 10px; top: -20px; animation: confettiFall linear forwards; }
+        @keyframes confettiFall { to { top: 110vh; transform: rotate(720deg); } }
+        .grade-tokutou{color:#FFD700;} .grade-ittou{color:#FF6666;} .grade-nittou{color:#6699FF;}
+        .grade-santou{color:#66CC66;} .grade-yontou{color:#FFDD44;} .grade-hazure{color:#AAAAAA;}
+        .no-history { color: #555; font-size: 0.9em; text-align: center; padding: 20px 0; }
         @media (max-width: 700px) {
             .header h1 { font-size: 1.8em; }
             .main-content { padding: 15px; gap: 20px; }
@@ -660,15 +428,11 @@ func homeHandler(w http.ResponseWriter, r *http.Request) {
     </style>
 </head>
 <body>
-
 <div class="header">
     <h1>🎰 商店街ガラガラポン抽選会 🎰</h1>
     <p>ハンドルを回して景品をゲットしよう！</p>
 </div>
-
 <div class="main-content">
-
-    <!-- ガラガラポンマシン -->
     <div class="machine-section">
         <div class="machine-wrapper">
             <div class="drum-container">
@@ -683,74 +447,53 @@ func homeHandler(w http.ResponseWriter, r *http.Request) {
                     </div>
                 </div>
             </div>
-
             <div class="outlet">
                 <span class="outlet-label">排出口</span>
                 <div class="result-ball" id="resultBall"></div>
             </div>
-
             <div class="machine-base"></div>
         </div>
-
-        <button class="draw-btn" id="drawBtn" onclick="startDraw()">
-            🎲 ガラガラ回す！
-        </button>
-
-        <div class="stats-bar" id="statsBar">
+        <button class="draw-btn" id="drawBtn" onclick="startDraw()">🎲 ガラガラ回す！</button>
+        <div class="stats-bar">
             <div class="stat-chip">総抽選数: <span id="totalDraws">0</span>回</div>
         </div>
     </div>
 
-    <!-- 右側パネル -->
     <div class="result-section">
-
-        <!-- 結果パネル -->
         <div class="result-panel" id="resultPanel">
             <p class="wait-msg">ボタンを押して抽選してみよう！</p>
         </div>
 
-        <!-- 景品表 -->
-        <div class="prize-table-section">
-            <h2>🎁 景品一覧</h2>
-            <div id="prizeTable"></div>
+        <div class="prize-table-section" id="prizeTableSection">
+            <div class="prize-table-header">
+                <h2>🎁 景品一覧</h2>
+                <span class="live-badge">LIVE</span>
+            </div>
+            <div class="rotation-timer">
+                🔄 次の確率変更まで
+                <span class="countdown-num" id="countdown">--</span>秒
+            </div>
+            <div id="prizeTable"><p style="color:#555;font-size:0.9em;">読込中...</p></div>
         </div>
 
-        <!-- 抽選履歴 -->
         <div class="history-section">
             <h2>📋 抽選履歴</h2>
-            <div id="history-list">
-                <p class="no-history">まだ抽選していません</p>
-            </div>
+            <div id="history-list"><p class="no-history">まだ抽選していません</p></div>
         </div>
-
     </div>
 </div>
-
 <div class="confetti-container" id="confettiContainer"></div>
 
 <script>
-// 景品データ（サーバーと同期）
-const prizes = [
-    { grade: "特等", name: "特等賞", desc: "豪華旅行券 ¥100,000", color: "#FFD700", prob: "0.5%", cls: "grade-tokutou" },
-    { grade: "1等", name: "1等賞", desc: "商品券 ¥10,000",      color: "#FF3333", prob: "3%",   cls: "grade-ittou" },
-    { grade: "2等", name: "2等賞", desc: "商品券 ¥5,000",       color: "#3366FF", prob: "7.5%", cls: "grade-nittou" },
-    { grade: "3等", name: "3等賞", desc: "商品券 ¥1,000",       color: "#33AA33", prob: "19%",  cls: "grade-santou" },
-    { grade: "4等", name: "4等賞", desc: "お買い物割引券 ¥500", color: "#FFCC00", prob: "20%",  cls: "grade-yontou" },
-    { grade: "参加賞", name: "参加賞", desc: "記念品プレゼント", color: "#D0D0D0", prob: "50%",  cls: "grade-hazure" },
-];
+const gradeClasses = {
+    "特等":"grade-tokutou","1等":"grade-ittou","2等":"grade-nittou",
+    "3等":"grade-santou","4等":"grade-yontou","参加賞":"grade-hazure"
+};
 
-// 景品テーブル描画
-function renderPrizeTable() {
-    const container = document.getElementById('prizeTable');
-    container.innerHTML = prizes.map(p => ` + "`" + `
-        <div class="prize-row">
-            <div class="ball-icon" style="background: radial-gradient(circle at 35% 35%, ${lighten(p.color)}, ${p.color} 70%);"></div>
-            <span class="prize-grade-label ${p.cls}">${p.grade}</span>
-            <span class="prize-prize-name">${p.desc}</span>
-            <span class="prize-prob">${p.prob}</span>
-        </div>
-    ` + "`" + `).join('');
-}
+let currentPrizes = [];
+let nextRotationAt = null;
+let isDrawing = false;
+let totalDraws = 0;
 
 function lighten(hex) {
     const r = parseInt(hex.slice(1,3),16);
@@ -759,16 +502,61 @@ function lighten(hex) {
     return ` + "`" + `rgb(${Math.min(255,r+80)},${Math.min(255,g+80)},${Math.min(255,b+80)})` + "`" + `;
 }
 
-// ドラム内にミニボールを配置
+function weightToProb(weight) {
+    return (weight / 10).toFixed(1) + '%';
+}
+
+async function fetchPrizes() {
+    try {
+        const res = await fetch('/api/prizes');
+        const info = await res.json();
+        nextRotationAt = new Date(info.next_rotation_at);
+
+        const weightsChanged = currentPrizes.length > 0 &&
+            currentPrizes.some((p, i) => p.weight !== info.prizes[i].weight);
+
+        currentPrizes = info.prizes;
+        renderPrizeTable();
+        populateDrum();
+
+        if (weightsChanged) {
+            flashPrizeTable();
+        }
+    } catch(e) {
+        console.error('景品取得エラー:', e);
+    }
+}
+
+function renderPrizeTable() {
+    if (!currentPrizes.length) return;
+    document.getElementById('prizeTable').innerHTML = currentPrizes.map(p => ` + "`" + `
+        <div class="prize-row">
+            <div class="ball-icon" style="background:radial-gradient(circle at 35% 35%, ${lighten(p.ball.hex)}, ${p.ball.hex} 70%);"></div>
+            <span class="prize-grade-label ${gradeClasses[p.grade] || ''}">${p.grade}</span>
+            <span class="prize-prize-name">${p.description}</span>
+            <span class="prize-prob">${weightToProb(p.weight)}</span>
+        </div>
+    ` + "`" + `).join('');
+}
+
+function flashPrizeTable() {
+    const sec = document.getElementById('prizeTableSection');
+    sec.classList.remove('flash');
+    void sec.offsetWidth;
+    sec.classList.add('flash');
+    setTimeout(() => sec.classList.remove('flash'), 800);
+}
+
 function populateDrum() {
+    if (!currentPrizes.length) return;
     const container = document.getElementById('drumBalls');
-    const colors = prizes.map(p => p.color);
+    const colors = currentPrizes.map(p => p.ball.hex);
     const positions = [
-        {top:'15%',left:'20%'}, {top:'15%',left:'55%'}, {top:'30%',left:'10%'},
-        {top:'30%',left:'40%'}, {top:'30%',left:'68%'}, {top:'50%',left:'15%'},
-        {top:'50%',left:'45%'}, {top:'50%',left:'72%'}, {top:'65%',left:'25%'},
-        {top:'65%',left:'55%'}, {top:'78%',left:'15%'}, {top:'78%',left:'42%'},
-        {top:'78%',left:'65%'}, {top:'20%',left:'75%'}, {top:'42%',left:'30%'},
+        {top:'15%',left:'20%'},{top:'15%',left:'55%'},{top:'30%',left:'10%'},
+        {top:'30%',left:'40%'},{top:'30%',left:'68%'},{top:'50%',left:'15%'},
+        {top:'50%',left:'45%'},{top:'50%',left:'72%'},{top:'65%',left:'25%'},
+        {top:'65%',left:'55%'},{top:'78%',left:'15%'},{top:'78%',left:'42%'},
+        {top:'78%',left:'65%'},{top:'20%',left:'75%'},{top:'42%',left:'30%'},
     ];
     container.innerHTML = positions.map((pos, i) => {
         const c = colors[i % colors.length];
@@ -776,8 +564,17 @@ function populateDrum() {
     }).join('');
 }
 
-let isDrawing = false;
-let totalDraws = 0;
+function updateCountdown() {
+    if (!nextRotationAt) return;
+    const remaining = Math.max(0, Math.ceil((nextRotationAt.getTime() - Date.now()) / 1000));
+    const el = document.getElementById('countdown');
+    if (!el) return;
+    el.textContent = remaining;
+    el.className = 'countdown-num' + (remaining <= 5 ? ' soon' : '');
+    if (remaining === 0) {
+        setTimeout(fetchPrizes, 600);
+    }
+}
 
 async function startDraw() {
     if (isDrawing) return;
@@ -790,19 +587,16 @@ async function startDraw() {
 
     btn.disabled = true;
     btn.textContent = '🎲 抽選中...';
-
-    // ドラムを回す
     drum.classList.add('spinning');
     resultBall.classList.remove('show');
     resultPanel.classList.remove('highlight');
     resultPanel.innerHTML = '<p style="color:#888;font-size:1.1em;">🎰 ガラガラ回転中...</p>';
 
-    // APIを呼び出す
     let result;
     try {
         const res = await fetch('/api/draw', { method: 'POST' });
         result = await res.json();
-    } catch (e) {
+    } catch(e) {
         resultPanel.innerHTML = '<p style="color:#f66;">エラーが発生しました</p>';
         drum.classList.remove('spinning');
         btn.disabled = false;
@@ -811,23 +605,15 @@ async function startDraw() {
         return;
     }
 
-    // 1.5秒後に結果表示
     setTimeout(() => {
         drum.classList.remove('spinning');
 
-        // ボール表示
         const ballColor = result.prize.ball.hex;
         resultBall.style.background = ` + "`" + `radial-gradient(circle at 35% 35%, ${lighten(ballColor)}, ${ballColor} 70%)` + "`" + `;
         resultBall.classList.add('show');
 
-        // 結果パネル
         const grade = result.prize.grade;
-        const gradeClass = {
-            '特等': 'grade-tokutou', '1等': 'grade-ittou', '2等': 'grade-nittou',
-            '3等': 'grade-santou', '4等': 'grade-yontou', '参加賞': 'grade-hazure'
-        }[grade] || 'grade-hazure';
-
-        const isWin = grade !== '参加賞';
+        const gradeClass = gradeClasses[grade] || 'grade-hazure';
 
         resultPanel.classList.add('highlight');
         resultPanel.innerHTML = ` + "`" + `
@@ -835,27 +621,18 @@ async function startDraw() {
             <div class="result-name">${result.prize.name}</div>
             <div class="result-desc">${result.prize.description}</div>
         ` + "`" + `;
+        setTimeout(() => { const rg = document.getElementById('rg'); if(rg) rg.classList.add('show'); }, 50);
 
-        setTimeout(() => {
-            const rg = document.getElementById('rg');
-            if (rg) rg.classList.add('show');
-        }, 50);
-
-        // 紙吹雪（特等・1等・2等）
         if (['特等','1等','2等'].includes(grade)) {
-            const count = grade === '特等' ? 80 : grade === '1等' ? 50 : 30;
-            launchConfetti(count);
+            launchConfetti(grade === '特等' ? 80 : grade === '1等' ? 50 : 30);
         }
 
-        // 履歴更新
         totalDraws++;
         document.getElementById('totalDraws').textContent = totalDraws;
         addHistory(result);
-
         btn.disabled = false;
         btn.textContent = '🎲 もう一度回す！';
         isDrawing = false;
-
     }, 1500);
 }
 
@@ -865,55 +642,36 @@ function addHistory(result) {
     if (noHistory) noHistory.remove();
 
     const grade = result.prize.grade;
-    const gradeClass = {
-        '特等': 'grade-tokutou', '1等': 'grade-ittou', '2等': 'grade-nittou',
-        '3等': 'grade-santou', '4等': 'grade-yontou', '参加賞': 'grade-hazure'
-    }[grade] || 'grade-hazure';
-
     const now = new Date();
-    const timeStr = now.toLocaleTimeString('ja-JP');
-
-    const ballColor = result.prize.ball.hex;
-
     const item = document.createElement('div');
     item.className = 'history-item';
     item.innerHTML = ` + "`" + `
-        <div class="ball-icon" style="width:16px;height:16px;flex-shrink:0;background:radial-gradient(circle at 35% 35%, ${lighten(ballColor)}, ${ballColor} 70%);border-radius:50%;"></div>
+        <div style="width:16px;height:16px;flex-shrink:0;border-radius:50%;background:radial-gradient(circle at 35% 35%, ${lighten(result.prize.ball.hex)}, ${result.prize.ball.hex} 70%);"></div>
         <span class="history-num">#${result.ticket_num}</span>
-        <span class="history-grade ${gradeClass}">${result.prize.grade}</span>
+        <span class="history-grade ${gradeClasses[grade] || ''}">${grade}</span>
         <span class="history-prize">${result.prize.description}</span>
-        <span class="history-time">${timeStr}</span>
+        <span class="history-time">${now.toLocaleTimeString('ja-JP')}</span>
     ` + "`" + `;
-
     list.insertBefore(item, list.firstChild);
-
-    // 最大20件表示
     const items = list.querySelectorAll('.history-item');
-    if (items.length > 20) {
-        items[items.length - 1].remove();
-    }
+    if (items.length > 20) items[items.length-1].remove();
 }
 
-// 紙吹雪
 function launchConfetti(count) {
     const container = document.getElementById('confettiContainer');
     const colors = ['#FFD700','#FF6666','#6699FF','#66CC66','#FF99CC','#FFCC44'];
-
     for (let i = 0; i < count; i++) {
         setTimeout(() => {
             const piece = document.createElement('div');
             piece.className = 'confetti-piece';
             const size = 6 + Math.random() * 10;
-            const isCircle = Math.random() > 0.5;
             piece.style.cssText = ` + "`" + `
-                left: ${Math.random() * 100}%;
-                width: ${size}px;
-                height: ${size}px;
-                background: ${colors[Math.floor(Math.random() * colors.length)]};
-                border-radius: ${isCircle ? '50%' : '2px'};
-                animation-duration: ${1.5 + Math.random() * 2}s;
-                animation-delay: ${Math.random() * 0.5}s;
-                opacity: ${0.6 + Math.random() * 0.4};
+                left:${Math.random()*100}%;width:${size}px;height:${size}px;
+                background:${colors[Math.floor(Math.random()*colors.length)]};
+                border-radius:${Math.random()>0.5?'50%':'2px'};
+                animation-duration:${1.5+Math.random()*2}s;
+                animation-delay:${Math.random()*0.5}s;
+                opacity:${0.6+Math.random()*0.4};
             ` + "`" + `;
             container.appendChild(piece);
             setTimeout(() => piece.remove(), 4000);
@@ -921,9 +679,12 @@ function launchConfetti(count) {
     }
 }
 
-// 初期化
-renderPrizeTable();
-populateDrum();
+// カウントダウンは毎秒更新
+setInterval(updateCountdown, 1000);
+// 景品テーブルは5秒ごとに同期（ローテーション後のズレを補正）
+setInterval(fetchPrizes, 5000);
+// 初期ロード
+fetchPrizes();
 </script>
 </body>
 </html>`
@@ -938,9 +699,7 @@ func apiDrawHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "POST only", http.StatusMethodNotAllowed)
 		return
 	}
-
 	result := drawLottery()
-
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(result)
 }
@@ -949,7 +708,6 @@ func apiDrawHandler(w http.ResponseWriter, r *http.Request) {
 func apiHistoryHandler(w http.ResponseWriter, r *http.Request) {
 	historyMu.Lock()
 	defer historyMu.Unlock()
-
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(history)
 }
@@ -961,13 +719,28 @@ func apiStatsHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(stats)
 }
 
-// 景品一覧APIハンドラ
+// 景品一覧APIハンドラ（ローテーション情報付き）
 func apiPrizesHandler(w http.ResponseWriter, r *http.Request) {
+	prizeMu.RLock()
+	ps := make([]Prize, len(prizes))
+	copy(ps, prizes)
+	nra := nextRotateAt
+	lra := lastRotatedAt
+	prizeMu.RUnlock()
+
+	info := PrizesInfo{
+		Prizes:              ps,
+		NextRotationAt:      nra,
+		LastRotatedAt:       lra,
+		RotationIntervalSec: int(rotationInterval.Seconds()),
+	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(prizes)
+	json.NewEncoder(w).Encode(info)
 }
 
 func main() {
+	startPrizeRotation()
+
 	http.HandleFunc("/", homeHandler)
 	http.HandleFunc("/api/draw", apiDrawHandler)
 	http.HandleFunc("/api/history", apiHistoryHandler)
@@ -977,7 +750,7 @@ func main() {
 	port := ":8081"
 	fmt.Println("🎰 ガラガラポン抽選システム起動中...")
 	fmt.Printf("🌐 http://localhost%s にアクセスしてください\n", port)
-	fmt.Println("🎁 景品: 特等(0.5%) / 1等(3%) / 2等(7.5%) / 3等(19%) / 4等(20%) / 参加賞(50%)")
+	fmt.Printf("🔄 当選確率は %v ごとに自動変更されます\n", rotationInterval)
 
 	if err := http.ListenAndServe(port, nil); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
【main.go】
- prizeMu (sync.RWMutex) で景品テーブルをスレッドセーフに保護
- generateNewWeights(): 各等級の重み範囲内でランダムに再生成（合計は必ず1000）
- rotatePrizes(): 30秒ごとに重みを更新し nextRotateAt/lastRotatedAt を記録
- startPrizeRotation(): バックグラウンドgoroutineでローテーション開始
- /api/prizes レスポンスに PrizesInfo 形式（次回変更時刻・間隔）を追加
- フロントエンド: リアルタイムカウントダウン表示・5秒ごと自動同期・変更時フラッシュアニメーション

【lottery_test.go】
- TestGenerateNewWeights_*: 200回試行で重み合計/正値/個数を確認
- TestRotatePrizes_*: 合計維持・lastRotatedAt更新・nextRotateAt更新・50回連続回転
- TestApiPrizesHandler_*: PrizesInfo形式の確認・重み合計の確認
- TestHomeHandler: countdown要素の存在確認を追加
- 全28テスト PASS

https://claude.ai/code/session_01VqBcdZmEGc1pfwVCfW7iUQ