### PR TITLE
feat: 東証急騰スキャナー（tse-scanner）を実装

### DIFF
--- a/tse-scanner/Makefile
+++ b/tse-scanner/Makefile
@@ -1,0 +1,87 @@
+# ==============================================================================
+# tse-scanner — 東証急騰スキャナー ビルドシステム
+# ==============================================================================
+BINARY    := tse-scanner
+GO        := go
+BUILD_DIR := bin
+PKG       := ./...
+COVERAGE  := $(BUILD_DIR)/coverage.out
+
+VERSION   ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+COMMIT    ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+LDFLAGS := -ldflags "\
+  -X main.version=$(VERSION) \
+  -X main.commit=$(COMMIT) \
+  -X main.buildDate=$(BUILD_DATE) \
+  -w -s"
+
+.DEFAULT_GOAL := help
+
+.PHONY: all build run test test-race test-cover vet fmt tidy clean help
+
+## all         : fmt → vet → test-race → build
+all: fmt vet test-race build
+
+## build       : bin/tse-scanner をビルド
+build: $(BUILD_DIR)
+	@echo ">> Building $(BINARY) $(VERSION) ..."
+	$(GO) build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY) .
+	@echo ">> Output: $(BUILD_DIR)/$(BINARY)"
+
+## run         : ビルドして実行（60秒間隔）
+run: build
+	./$(BUILD_DIR)/$(BINARY) -interval 60s
+
+## run-fast    : 30秒間隔で実行（デモ用）
+run-fast: build
+	./$(BUILD_DIR)/$(BINARY) -interval 30s -min-score 10
+
+## test        : ユニットテスト
+test:
+	@echo ">> Running tests ..."
+	$(GO) test -v $(PKG)
+
+## test-race   : データ競合検出つきテスト
+test-race:
+	@echo ">> Running tests with race detector ..."
+	$(GO) test -race -v $(PKG)
+
+## test-cover  : カバレッジ計測 → bin/coverage.html
+test-cover: $(BUILD_DIR)
+	@echo ">> Running tests with coverage ..."
+	$(GO) test -race -coverprofile=$(COVERAGE) -covermode=atomic $(PKG)
+	$(GO) tool cover -func=$(COVERAGE)
+	$(GO) tool cover -html=$(COVERAGE) -o $(BUILD_DIR)/coverage.html
+	@echo ">> Report: $(BUILD_DIR)/coverage.html"
+
+## vet         : go vet 静的解析
+vet:
+	$(GO) vet $(PKG)
+
+## fmt         : go fmt フォーマット
+fmt:
+	$(GO) fmt $(PKG)
+
+## tidy        : go.mod 整理
+tidy:
+	$(GO) mod tidy
+
+## clean       : ビルド成果物を削除
+clean:
+	rm -rf $(BUILD_DIR)
+
+$(BUILD_DIR):
+	@mkdir -p $(BUILD_DIR)
+
+## help        : このヘルプを表示
+help:
+	@echo ""
+	@echo "  📈 tse-scanner 東証急騰スキャナー"
+	@echo ""
+	@grep -E '^## ' $(MAKEFILE_LIST) | \
+	  awk -F ':' '{ printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2 }'
+	@echo ""
+	@echo "  VERSION=$(VERSION)"
+	@echo ""

--- a/tse-scanner/analyzer/surge.go
+++ b/tse-scanner/analyzer/surge.go
@@ -1,0 +1,124 @@
+// Package analyzer computes surge scores and detects bullish signals.
+//
+// Scoring model (最大 100 点):
+//
+//	[A] 騰落率スコア  (0–40 点): 終値比上昇率に比例。+5% で満点。
+//	[B] 出来高スコア  (0–30 点): 3ヶ月平均比の出来高倍率に比例。4 倍で満点。
+//	[C] 高値圏スコア  (0–20 点): 当日高値と現値の乖離が小さいほど高い。
+//	[D] 新高値スコア  (0–10 点): 52 週高値更新・接近で加点。
+package analyzer
+
+import (
+	"math"
+	"sort"
+
+	"tse-scanner/model"
+)
+
+// thresholds for signal generation
+const (
+	thresholdVolumeSpike  = 2.0  // 出来高急増と判定する倍率（平均の 2 倍以上）
+	thresholdBigRise      = 5.0  // 大幅上昇と判定する騰落率（%）
+	thresholdRise         = 3.0  // 上昇トレンドと判定する騰落率（%）
+	thresholdNearHigh     = 0.98 // 当日高値の 98% 以上を「高値圏」と判定
+	thresholdNear52W      = 0.99 // 52 週高値の 99% 以上を「新高値圏」と判定
+	thresholdAboveOpen    = 0.0  // 寄り付き以上なら「陽線」
+	maxPriceChangeForFull = 5.0  // 騰落率スコア満点となる上昇率（%）
+	maxVolumeRatioForFull = 4.0  // 出来高スコア満点となる倍率
+)
+
+// Analyze returns surge candidates from the given quotes, sorted by SurgeScore desc.
+// Quotes with Valid=false or SurgeScore below minScore are excluded.
+func Analyze(quotes []model.Quote, minScore float64) []model.Candidate {
+	candidates := make([]model.Candidate, 0, len(quotes))
+
+	for _, q := range quotes {
+		if !q.Valid {
+			continue
+		}
+		volRatio := volumeRatio(q)
+		score, signals := scoreQuote(q, volRatio)
+
+		if score < minScore {
+			continue
+		}
+		candidates = append(candidates, model.Candidate{
+			Quote:       q,
+			VolumeRatio: volRatio,
+			SurgeScore:  score,
+			Signals:     signals,
+		})
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].SurgeScore > candidates[j].SurgeScore
+	})
+	return candidates
+}
+
+// scoreQuote computes the composite surge score and collects triggered signals.
+func scoreQuote(q model.Quote, volRatio float64) (float64, []model.Signal) {
+	var signals []model.Signal
+	total := 0.0
+
+	// ---- [A] 騰落率スコア (0–40 pt) ----
+	if q.ChangePercent > 0 {
+		priceScore := math.Min(q.ChangePercent/maxPriceChangeForFull, 1.0) * 40.0
+		total += priceScore
+		signals = append(signals, model.Signal{Label: "騰落率", Score: priceScore})
+
+		if q.ChangePercent >= thresholdBigRise {
+			signals = append(signals, model.Signal{Label: "🚀大幅上昇", Score: 0})
+		} else if q.ChangePercent >= thresholdRise {
+			signals = append(signals, model.Signal{Label: "📈上昇トレンド", Score: 0})
+		}
+	}
+
+	// ---- [B] 出来高スコア (0–30 pt) ----
+	if volRatio > 1.0 {
+		volScore := math.Min((volRatio-1.0)/(maxVolumeRatioForFull-1.0), 1.0) * 30.0
+		total += volScore
+		signals = append(signals, model.Signal{Label: "出来高", Score: volScore})
+
+		if volRatio >= thresholdVolumeSpike {
+			signals = append(signals, model.Signal{Label: "⚡出来高急増", Score: 0})
+		}
+	}
+
+	// ---- [C] 高値圏スコア (0–20 pt) ----
+	if q.DayHigh > 0 && q.Price > 0 {
+		proximity := q.Price / q.DayHigh // 1.0 = 当日最高値ぴったり
+		if proximity >= thresholdNearHigh {
+			highScore := proximity * 20.0
+			total += highScore
+			signals = append(signals, model.Signal{Label: "高値圏", Score: highScore})
+			signals = append(signals, model.Signal{Label: "🔼高値圏推移", Score: 0})
+		}
+	}
+
+	// ---- [D] 52 週高値スコア (0–10 pt) ----
+	if q.WeekHigh52 > 0 && q.Price > 0 {
+		ratio52 := q.Price / q.WeekHigh52
+		if ratio52 >= thresholdNear52W {
+			w52Score := ratio52 * 10.0
+			total += w52Score
+			signals = append(signals, model.Signal{Label: "52週高値", Score: w52Score})
+			if ratio52 >= 1.0 {
+				signals = append(signals, model.Signal{Label: "🏆52週新高値", Score: 0})
+			} else {
+				signals = append(signals, model.Signal{Label: "🎯52週高値圏", Score: 0})
+			}
+		}
+	}
+
+	return math.Min(total, 100.0), signals
+}
+
+// volumeRatio returns current volume / 3-month average volume.
+// Returns 1.0 if average volume is unavailable (neutral).
+func volumeRatio(q model.Quote) float64 {
+	if q.AvgVolume3M <= 0 {
+		return 1.0
+	}
+	return float64(q.Volume) / float64(q.AvgVolume3M)
+}

--- a/tse-scanner/analyzer/surge_test.go
+++ b/tse-scanner/analyzer/surge_test.go
@@ -1,0 +1,442 @@
+package analyzer_test
+
+import (
+	"math"
+	"testing"
+
+	"tse-scanner/analyzer"
+	"tse-scanner/model"
+)
+
+// ---- helpers ----
+
+func newQuote(changePercent float64, volRatio float64, price, dayHigh, weekHigh52 float64) model.Quote {
+	avgVol := int64(1000000)
+	vol := int64(float64(avgVol) * volRatio)
+	return model.Quote{
+		Symbol:        "TEST.T",
+		Name:          "テスト株式",
+		Sector:        "テスト",
+		Price:         price,
+		ChangePercent: changePercent,
+		Volume:        vol,
+		AvgVolume3M:   avgVol,
+		DayHigh:       dayHigh,
+		WeekHigh52:    weekHigh52,
+		Valid:          true,
+	}
+}
+
+func hasSignal(signals []model.Signal, label string) bool {
+	for _, s := range signals {
+		if s.Label == label {
+			return true
+		}
+	}
+	return false
+}
+
+func totalScore(signals []model.Signal) float64 {
+	total := 0.0
+	for _, s := range signals {
+		total += s.Score
+	}
+	return total
+}
+
+// ---- Analyze function tests ----
+
+func TestAnalyze_ExcludesInvalidQuotes(t *testing.T) {
+	quotes := []model.Quote{
+		{Symbol: "A.T", Valid: false, ChangePercent: 10},
+		newQuote(5.0, 3.0, 1000, 1010, 1200),
+	}
+	results := analyzer.Analyze(quotes, 0)
+	if len(results) != 1 {
+		t.Errorf("want 1 candidate, got %d", len(results))
+	}
+	if results[0].Symbol != "TEST.T" {
+		t.Errorf("unexpected symbol: %s", results[0].Symbol)
+	}
+}
+
+func TestAnalyze_ExcludesBelowMinScore(t *testing.T) {
+	quotes := []model.Quote{
+		newQuote(1.0, 1.1, 1000, 1100, 2000), // low score
+		newQuote(5.0, 4.0, 1000, 1000, 1010), // high score
+	}
+	results := analyzer.Analyze(quotes, 50.0)
+	for _, r := range results {
+		if r.SurgeScore < 50.0 {
+			t.Errorf("candidate %s has score %f below minScore 50", r.Symbol, r.SurgeScore)
+		}
+	}
+}
+
+func TestAnalyze_SortedByScoreDescending(t *testing.T) {
+	quotes := []model.Quote{
+		newQuote(1.0, 1.5, 1000, 1100, 2000),
+		newQuote(5.0, 4.0, 1000, 1000, 1010),
+		newQuote(3.0, 2.5, 1000, 1050, 1500),
+	}
+	results := analyzer.Analyze(quotes, 0)
+	for i := 1; i < len(results); i++ {
+		if results[i].SurgeScore > results[i-1].SurgeScore {
+			t.Errorf("results not sorted: index %d (%f) > index %d (%f)",
+				i, results[i].SurgeScore, i-1, results[i-1].SurgeScore)
+		}
+	}
+}
+
+func TestAnalyze_EmptyInput(t *testing.T) {
+	results := analyzer.Analyze([]model.Quote{}, 0)
+	if results == nil {
+		t.Error("want empty slice, got nil")
+	}
+	if len(results) != 0 {
+		t.Errorf("want 0 results, got %d", len(results))
+	}
+}
+
+func TestAnalyze_AllInvalid(t *testing.T) {
+	quotes := []model.Quote{
+		{Symbol: "A.T", Valid: false},
+		{Symbol: "B.T", Valid: false},
+	}
+	results := analyzer.Analyze(quotes, 0)
+	if len(results) != 0 {
+		t.Errorf("want 0 results, got %d", len(results))
+	}
+}
+
+// ---- Score component tests ----
+
+func TestScore_PriceComponent_Zero_WhenNoChange(t *testing.T) {
+	q := newQuote(0, 1.0, 1000, 1100, 2000)
+	results := analyzer.Analyze([]model.Quote{q}, 0)
+	if len(results) == 0 {
+		return // score 0, filtered out is fine
+	}
+	// Price score should not be present for 0% change
+	if hasSignal(results[0].Signals, "騰落率") {
+		t.Error("should not have 騰落率 signal for 0% change")
+	}
+}
+
+func TestScore_PriceComponent_FullAt5Percent(t *testing.T) {
+	// +5% change with no other signals → price score = 40
+	q := newQuote(5.0, 1.0, 1000, 1100, 2000)
+	results := analyzer.Analyze([]model.Quote{q}, 0)
+	if len(results) == 0 {
+		t.Fatal("expected at least 1 result")
+	}
+	found := false
+	for _, s := range results[0].Signals {
+		if s.Label == "騰落率" {
+			if math.Abs(s.Score-40.0) > 0.01 {
+				t.Errorf("want price score 40.0 at 5%%, got %f", s.Score)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Error("want 騰落率 signal")
+	}
+}
+
+func TestScore_PriceComponent_CappedAt40(t *testing.T) {
+	// +20% change → price score still capped at 40
+	q := newQuote(20.0, 1.0, 1000, 1100, 2000)
+	results := analyzer.Analyze([]model.Quote{q}, 0)
+	if len(results) == 0 {
+		t.Fatal("expected at least 1 result")
+	}
+	for _, s := range results[0].Signals {
+		if s.Label == "騰落率" && s.Score > 40.01 {
+			t.Errorf("price score should be capped at 40, got %f", s.Score)
+		}
+	}
+}
+
+func TestScore_PriceComponent_NegativeChange_NoSignal(t *testing.T) {
+	q := newQuote(-3.0, 1.0, 1000, 1100, 2000)
+	results := analyzer.Analyze([]model.Quote{q}, 0)
+	for _, r := range results {
+		if hasSignal(r.Signals, "騰落率") {
+			t.Error("should not have 騰落率 signal for negative change")
+		}
+	}
+}
+
+func TestScore_VolumeComponent_Zero_WhenBelowAverage(t *testing.T) {
+	// Volume ratio = 0.5 (below average) → no volume score
+	q := newQuote(3.0, 0.5, 1000, 1100, 2000)
+	results := analyzer.Analyze([]model.Quote{q}, 0)
+	if len(results) > 0 {
+		if hasSignal(results[0].Signals, "出来高") {
+			t.Error("should not have 出来高 signal when volume ratio < 1")
+		}
+	}
+}
+
+func TestScore_VolumeComponent_FullAt4x(t *testing.T) {
+	// Volume ratio = 4.0 → volume score = 30
+	q := newQuote(0, 4.0, 1000, 1100, 2000)
+	results := analyzer.Analyze([]model.Quote{q}, 0)
+	if len(results) == 0 {
+		t.Fatal("expected at least 1 result")
+	}
+	for _, s := range results[0].Signals {
+		if s.Label == "出来高" {
+			if math.Abs(s.Score-30.0) > 0.01 {
+				t.Errorf("want volume score 30.0 at 4x, got %f", s.Score)
+			}
+		}
+	}
+}
+
+func TestScore_VolumeComponent_NoAvgVolume_NeutralRatio(t *testing.T) {
+	// When AvgVolume3M = 0, volumeRatio should return 1.0 (neutral, no score)
+	q := newQuote(3.0, 1.0, 1000, 1100, 2000)
+	q.AvgVolume3M = 0
+	q.Volume = 999999
+	results := analyzer.Analyze([]model.Quote{q}, 0)
+	if len(results) > 0 {
+		if hasSignal(results[0].Signals, "出来高") {
+			t.Error("should not have 出来高 signal when AvgVolume3M=0")
+		}
+	}
+}
+
+func TestScore_DayHighComponent_AddedWhenNear(t *testing.T) {
+	// Price = DayHigh → proximity = 1.0 → high score = 20
+	q := newQuote(0, 1.0, 1000, 1000, 2000)
+	results := analyzer.Analyze([]model.Quote{q}, 0)
+	if len(results) == 0 {
+		t.Fatal("expected at least 1 result")
+	}
+	if !hasSignal(results[0].Signals, "高値圏") {
+		t.Error("want 高値圏 signal when price == day high")
+	}
+}
+
+func TestScore_DayHighComponent_SkippedWhenFarFromHigh(t *testing.T) {
+	// Price = 90% of DayHigh → proximity = 0.9 < threshold 0.98
+	q := newQuote(0, 1.0, 900, 1000, 2000)
+	results := analyzer.Analyze([]model.Quote{q}, 0)
+	for _, r := range results {
+		if hasSignal(r.Signals, "高値圏") {
+			t.Error("should not have 高値圏 signal when price far from day high")
+		}
+	}
+}
+
+func TestScore_52WeekHigh_AddedWhenNear(t *testing.T) {
+	// Price >= 99% of 52-week high
+	q := newQuote(0, 1.0, 990, 1100, 1000)
+	results := analyzer.Analyze([]model.Quote{q}, 0)
+	if len(results) == 0 {
+		t.Fatal("expected at least 1 result")
+	}
+	if !hasSignal(results[0].Signals, "52週高値") {
+		t.Error("want 52週高値 signal when price near 52-week high")
+	}
+}
+
+func TestScore_52WeekNewHigh_Signal(t *testing.T) {
+	// Price >= 52-week high → 🏆新高値
+	q := newQuote(0, 1.0, 1100, 1200, 1000)
+	results := analyzer.Analyze([]model.Quote{q}, 0)
+	if len(results) == 0 {
+		t.Fatal("expected at least 1 result")
+	}
+	if !hasSignal(results[0].Signals, "🏆52週新高値") {
+		t.Error("want 🏆52週新高値 signal when price exceeds 52-week high")
+	}
+}
+
+func TestScore_52WeekNearHigh_Signal(t *testing.T) {
+	// Price = 99.5% of 52-week high → 🎯高値圏
+	q := newQuote(0, 1.0, 995, 1100, 1000)
+	results := analyzer.Analyze([]model.Quote{q}, 0)
+	if len(results) == 0 {
+		t.Fatal("expected at least 1 result")
+	}
+	if !hasSignal(results[0].Signals, "🎯52週高値圏") {
+		t.Error("want 🎯52週高値圏 signal when price near (but below) 52-week high")
+	}
+}
+
+// ---- Signal detection tests ----
+
+func TestSignals_BigRise(t *testing.T) {
+	q := newQuote(6.0, 1.0, 1000, 1100, 2000)
+	results := analyzer.Analyze([]model.Quote{q}, 0)
+	if len(results) == 0 {
+		t.Fatal("expected at least 1 result")
+	}
+	if !hasSignal(results[0].Signals, "🚀大幅上昇") {
+		t.Error("want 🚀大幅上昇 signal for >= 5% change")
+	}
+}
+
+func TestSignals_RiseTrend(t *testing.T) {
+	q := newQuote(4.0, 1.0, 1000, 1100, 2000)
+	results := analyzer.Analyze([]model.Quote{q}, 0)
+	if len(results) == 0 {
+		t.Fatal("expected at least 1 result")
+	}
+	if !hasSignal(results[0].Signals, "📈上昇トレンド") {
+		t.Error("want 📈上昇トレンド signal for 3-5% change")
+	}
+	if hasSignal(results[0].Signals, "🚀大幅上昇") {
+		t.Error("should not have 🚀大幅上昇 for 4% change")
+	}
+}
+
+func TestSignals_VolumeSpike(t *testing.T) {
+	q := newQuote(0, 3.0, 1000, 1100, 2000)
+	results := analyzer.Analyze([]model.Quote{q}, 0)
+	if len(results) == 0 {
+		t.Fatal("expected at least 1 result")
+	}
+	if !hasSignal(results[0].Signals, "⚡出来高急増") {
+		t.Error("want ⚡出来高急増 signal for >= 2x volume")
+	}
+}
+
+func TestSignals_DayHighProximity(t *testing.T) {
+	q := newQuote(0, 1.0, 999, 1000, 2000) // 99.9% of day high
+	results := analyzer.Analyze([]model.Quote{q}, 0)
+	if len(results) == 0 {
+		t.Fatal("expected at least 1 result")
+	}
+	if !hasSignal(results[0].Signals, "🔼高値圏推移") {
+		t.Error("want 🔼高値圏推移 signal when near day high")
+	}
+}
+
+// ---- Score bounds ----
+
+func TestScore_MaxIs100(t *testing.T) {
+	// Perfect score scenario: +20%, 10x volume, price == day high == 52w high
+	q := newQuote(20.0, 10.0, 1000, 1000, 1000)
+	results := analyzer.Analyze([]model.Quote{q}, 0)
+	if len(results) == 0 {
+		t.Fatal("expected at least 1 result")
+	}
+	if results[0].SurgeScore > 100.0 {
+		t.Errorf("score should be capped at 100, got %f", results[0].SurgeScore)
+	}
+}
+
+func TestScore_ZeroWhenAllNeutral(t *testing.T) {
+	q := model.Quote{
+		Symbol:      "ZERO.T",
+		Price:       1000,
+		DayHigh:     2000, // far from high
+		WeekHigh52:  3000, // far from 52w high
+		AvgVolume3M: 1000000,
+		Volume:      500000, // below average
+		Valid:       true,
+	}
+	results := analyzer.Analyze([]model.Quote{q}, 0)
+	for _, r := range results {
+		if r.SurgeScore != 0 {
+			t.Errorf("want score 0 for neutral quote, got %f", r.SurgeScore)
+		}
+	}
+}
+
+// ---- VolumeRatio field ----
+
+func TestCandidate_VolumeRatioSet(t *testing.T) {
+	q := newQuote(5.0, 3.0, 1000, 1050, 2000)
+	results := analyzer.Analyze([]model.Quote{q}, 0)
+	if len(results) == 0 {
+		t.Fatal("expected at least 1 result")
+	}
+	if math.Abs(results[0].VolumeRatio-3.0) > 0.01 {
+		t.Errorf("want VolumeRatio 3.0, got %f", results[0].VolumeRatio)
+	}
+}
+
+func TestCandidate_VolumeRatioNeutralWhenNoAvg(t *testing.T) {
+	q := newQuote(5.0, 1.0, 1000, 1050, 2000)
+	q.AvgVolume3M = 0
+	results := analyzer.Analyze([]model.Quote{q}, 0)
+	if len(results) == 0 {
+		t.Fatal("expected at least 1 result")
+	}
+	if results[0].VolumeRatio != 1.0 {
+		t.Errorf("want VolumeRatio 1.0 when AvgVolume3M=0, got %f", results[0].VolumeRatio)
+	}
+}
+
+// ---- Boundary tests ----
+
+func TestScore_Exactly5PercentChange(t *testing.T) {
+	q := newQuote(5.0, 1.0, 1000, 1100, 2000)
+	results := analyzer.Analyze([]model.Quote{q}, 0)
+	if len(results) == 0 {
+		t.Fatal("expected at least 1 result")
+	}
+	// At exactly 5% we expect 🚀大幅上昇 (>= 5.0)
+	if !hasSignal(results[0].Signals, "🚀大幅上昇") {
+		t.Error("want 🚀大幅上昇 at exactly 5% change")
+	}
+}
+
+func TestScore_Exactly3PercentChange(t *testing.T) {
+	q := newQuote(3.0, 1.0, 1000, 1100, 2000)
+	results := analyzer.Analyze([]model.Quote{q}, 0)
+	if len(results) == 0 {
+		t.Fatal("expected at least 1 result")
+	}
+	if !hasSignal(results[0].Signals, "📈上昇トレンド") {
+		t.Error("want 📈上昇トレンド at exactly 3% change")
+	}
+}
+
+func TestScore_Exactly2xVolume(t *testing.T) {
+	q := newQuote(0, 2.0, 1000, 1100, 2000)
+	results := analyzer.Analyze([]model.Quote{q}, 0)
+	if len(results) == 0 {
+		t.Fatal("expected at least 1 result")
+	}
+	if !hasSignal(results[0].Signals, "⚡出来高急増") {
+		t.Error("want ⚡出来高急増 at exactly 2x volume")
+	}
+}
+
+func TestScore_DayHighZero_SkipsComponent(t *testing.T) {
+	q := newQuote(5.0, 3.0, 1000, 0, 0)
+	results := analyzer.Analyze([]model.Quote{q}, 0)
+	if len(results) == 0 {
+		t.Fatal("expected at least 1 result")
+	}
+	if hasSignal(results[0].Signals, "高値圏") {
+		t.Error("should skip 高値圏 component when DayHigh=0")
+	}
+	if hasSignal(results[0].Signals, "52週高値") {
+		t.Error("should skip 52週高値 component when WeekHigh52=0")
+	}
+}
+
+func TestScore_PriceZero_SkipsDayHighComponent(t *testing.T) {
+	q := model.Quote{
+		Symbol:      "Z.T",
+		Price:       0,
+		DayHigh:     1000,
+		WeekHigh52:  1000,
+		AvgVolume3M: 1000000,
+		Volume:      3000000,
+		Valid:       true,
+	}
+	results := analyzer.Analyze([]model.Quote{q}, 0)
+	for _, r := range results {
+		if hasSignal(r.Signals, "高値圏") {
+			t.Error("should skip 高値圏 when Price=0")
+		}
+	}
+}

--- a/tse-scanner/display/display.go
+++ b/tse-scanner/display/display.go
@@ -1,0 +1,189 @@
+// Package display renders scan results to the terminal using ANSI escape codes.
+package display
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"tse-scanner/model"
+)
+
+// ANSI escape codes
+const (
+	reset     = "\033[0m"
+	bold      = "\033[1m"
+	red       = "\033[31m"
+	green     = "\033[32m"
+	yellow    = "\033[33m"
+	blue      = "\033[34m"
+	magenta   = "\033[35m"
+	cyan      = "\033[36m"
+	white     = "\033[37m"
+	bgRed     = "\033[41m"
+	bgYellow  = "\033[43m"
+	clearLine = "\033[2K"
+	clearScr  = "\033[2J\033[H"
+)
+
+// Render clears the screen and draws the full scan report.
+func Render(candidates []model.Candidate, fetchedAt time.Time, interval time.Duration, totalScanned int) {
+	fmt.Print(clearScr)
+	printHeader(fetchedAt, interval, totalScanned, len(candidates))
+	if len(candidates) == 0 {
+		fmt.Printf("\n  %s急騰候補が見つかりませんでした。しばらくお待ちください。%s\n", yellow, reset)
+	} else {
+		printTable(candidates)
+	}
+	printFooter()
+}
+
+func printHeader(fetchedAt time.Time, interval time.Duration, total, found int) {
+	jst := time.FixedZone("JST", 9*60*60)
+	ts := fetchedAt.In(jst).Format("2006-01-02 15:04:05")
+	status := marketStatus(fetchedAt.In(jst))
+	nextIn := interval.Round(time.Second)
+
+	fmt.Printf("%s%s", bold, cyan)
+	fmt.Println("╔══════════════════════════════════════════════════════════════════════════════╗")
+	fmt.Printf("║  🔥 東証急騰スキャナー  %-20s  次回更新: %-8v       ║\n", ts, nextIn)
+	fmt.Printf("║  市場: %-10s  スキャン: %3d 銘柄  急騰候補: %3d 銘柄                  ║\n",
+		status, total, found)
+	fmt.Println("╚══════════════════════════════════════════════════════════════════════════════╝")
+	fmt.Print(reset)
+}
+
+func printTable(candidates []model.Candidate) {
+	header := fmt.Sprintf("  %s%-6s  %-8s  %-18s  %-8s  %10s  %7s  %6s  %s%s",
+		bold,
+		"SCORE", "コード", "銘柄名", "業種", "現在値(円)", "騰落率", "出来高比", "シグナル",
+		reset)
+	fmt.Println()
+	fmt.Println(header)
+	fmt.Printf("  %s\n", strings.Repeat("─", 80))
+
+	for _, c := range candidates {
+		printRow(c)
+	}
+}
+
+func printRow(c model.Candidate) {
+	scoreColor := scoreToColor(c.SurgeScore)
+	changeColor := green
+	sign := "+"
+	if c.ChangePercent < 0 {
+		changeColor = red
+		sign = ""
+	}
+
+	volStr := "  N/A "
+	if c.AvgVolume3M > 0 {
+		volStr = fmt.Sprintf("%5.1fx", c.VolumeRatio)
+	}
+
+	// Collect display-only signals (those whose Label starts with emoji)
+	var sigLabels []string
+	for _, s := range c.Signals {
+		if isDisplaySignal(s.Label) {
+			sigLabels = append(sigLabels, s.Label)
+		}
+	}
+	sigStr := strings.Join(sigLabels, " ")
+
+	// Pad Japanese name to fixed display width
+	paddedName := padJP(c.Name, 18)
+
+	codeStr := strings.TrimSuffix(c.Symbol, ".T")
+
+	fmt.Printf("  %s%6.1f%s  %-8s  %s  %-8s  %10s  %s%s%7.2f%%%s  %6s  %s\n",
+		scoreColor, c.SurgeScore, reset,
+		codeStr,
+		paddedName,
+		c.Sector,
+		formatPrice(c.Price),
+		changeColor, sign, c.ChangePercent, reset,
+		volStr,
+		sigStr,
+	)
+}
+
+func printFooter() {
+	fmt.Printf("\n  %s%s⚠ 投資は自己責任です。このツールは情報提供のみを目的としています。%s\n",
+		bold, yellow, reset)
+}
+
+// ---- helpers ----
+
+func marketStatus(now time.Time) string {
+	h, m, _ := now.Clock()
+	mins := h*60 + m
+	wd := now.Weekday()
+	if wd == time.Saturday || wd == time.Sunday {
+		return "🔴 休場（週末）"
+	}
+	// 前場 9:00–11:30、後場 12:30–15:30
+	if (mins >= 9*60 && mins < 11*60+30) || (mins >= 12*60+30 && mins < 15*60+30) {
+		return "🟢 取引中"
+	}
+	if mins >= 8*60 && mins < 9*60 {
+		return "🟡 前場前"
+	}
+	if mins >= 15*60+30 {
+		return "🔴 取引終了"
+	}
+	return "🟡 昼休み"
+}
+
+func scoreToColor(score float64) string {
+	switch {
+	case score >= 80:
+		return bold + red
+	case score >= 60:
+		return bold + yellow
+	case score >= 40:
+		return bold + cyan
+	default:
+		return white
+	}
+}
+
+func formatPrice(p float64) string {
+	if p >= 10000 {
+		return fmt.Sprintf("%10.0f", math.Round(p))
+	}
+	return fmt.Sprintf("%10.1f", p)
+}
+
+// isDisplaySignal returns true for emoji-prefixed signal labels (visual indicators).
+func isDisplaySignal(label string) bool {
+	if label == "" {
+		return false
+	}
+	// Emoji code points are >= 0x1F000
+	r, _ := utf8.DecodeRuneInString(label)
+	return r > 0x1F000
+}
+
+// padJP pads a string containing Japanese characters to targetDisplayWidth.
+// CJK characters count as 2 display columns.
+func padJP(s string, targetDisplayWidth int) string {
+	width := displayWidth(s)
+	if width >= targetDisplayWidth {
+		return s
+	}
+	return s + strings.Repeat(" ", targetDisplayWidth-width)
+}
+
+func displayWidth(s string) int {
+	w := 0
+	for _, r := range s {
+		if r > 0x1000 { // CJK and emoji: 2 columns
+			w += 2
+		} else {
+			w++
+		}
+	}
+	return w
+}

--- a/tse-scanner/fetcher/yahoo.go
+++ b/tse-scanner/fetcher/yahoo.go
@@ -1,0 +1,193 @@
+// Package fetcher retrieves real-time stock quotes from Yahoo Finance.
+// Yahoo Finance provides public JSON endpoints for Japanese stocks (*.T suffix).
+package fetcher
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"tse-scanner/model"
+)
+
+const (
+	baseURL   = "https://query1.finance.yahoo.com/v7/finance/quote"
+	batchSize = 50 // Yahoo Finance accepts up to ~100 symbols per request
+	userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+
+// HTTPDoer is the interface satisfied by *http.Client, enabling test injection.
+type HTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// Client wraps an HTTP client and fetches Yahoo Finance quotes.
+type Client struct {
+	http HTTPDoer
+}
+
+// New returns a Client with a production HTTP client (10s timeout).
+func New() *Client {
+	return &Client{
+		http: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+// NewWithHTTP returns a Client using the provided HTTPDoer (for testing).
+func NewWithHTTP(h HTTPDoer) *Client {
+	return &Client{http: h}
+}
+
+// FetchQuotes fetches quotes for all stocks in the watchlist.
+// Requests are batched to avoid hitting rate limits.
+// Stocks that fail to fetch are returned as Quote{Valid: false}.
+func (c *Client) FetchQuotes(ctx context.Context, stocks []model.Stock) ([]model.Quote, error) {
+	// Build symbol→Stock lookup for fast merging
+	lookup := make(map[string]model.Stock, len(stocks))
+	for _, s := range stocks {
+		lookup[s.Symbol] = s
+	}
+
+	results := make([]model.Quote, 0, len(stocks))
+	for i := 0; i < len(stocks); i += batchSize {
+		end := i + batchSize
+		if end > len(stocks) {
+			end = len(stocks)
+		}
+		batch := stocks[i:end]
+
+		quotes, err := c.fetchBatch(ctx, batch, lookup)
+		if err != nil {
+			// Partial failure: fill batch as invalid and continue
+			for _, s := range batch {
+				results = append(results, model.Quote{
+					Symbol: s.Symbol, Name: s.Name, Sector: s.Sector,
+					Valid: false,
+				})
+			}
+			continue
+		}
+		results = append(results, quotes...)
+	}
+	return results, nil
+}
+
+// fetchBatch fetches one batch of up to batchSize symbols.
+func (c *Client) fetchBatch(ctx context.Context, batch []model.Stock, lookup map[string]model.Stock) ([]model.Quote, error) {
+	symbols := make([]string, len(batch))
+	for i, s := range batch {
+		symbols[i] = s.Symbol
+	}
+
+	url := fmt.Sprintf("%s?symbols=%s&fields=shortName,regularMarketPrice,regularMarketChange,regularMarketChangePercent,regularMarketVolume,averageDailyVolume3Month,regularMarketDayHigh,regularMarketDayLow,regularMarketOpen,regularMarketPreviousClose,fiftyTwoWeekHigh,fiftyTwoWeekLow",
+		baseURL, strings.Join(symbols, ","))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("リクエスト作成エラー: %w", err)
+	}
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTPリクエストエラー: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTPステータス %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("レスポンス読み込みエラー: %w", err)
+	}
+
+	return parseResponse(body, lookup, batch)
+}
+
+// ---- Yahoo Finance JSON response types ----
+
+type yahooResponse struct {
+	QuoteResponse struct {
+		Result []yahooQuote `json:"result"`
+		Error  *struct {
+			Code        string `json:"code"`
+			Description string `json:"description"`
+		} `json:"error"`
+	} `json:"quoteResponse"`
+}
+
+type yahooQuote struct {
+	Symbol                    string  `json:"symbol"`
+	ShortName                 string  `json:"shortName"`
+	RegularMarketPrice        float64 `json:"regularMarketPrice"`
+	RegularMarketChange       float64 `json:"regularMarketChange"`
+	RegularMarketChangePercent float64 `json:"regularMarketChangePercent"`
+	RegularMarketVolume       int64   `json:"regularMarketVolume"`
+	AverageDailyVolume3Month  int64   `json:"averageDailyVolume3Month"`
+	RegularMarketDayHigh      float64 `json:"regularMarketDayHigh"`
+	RegularMarketDayLow       float64 `json:"regularMarketDayLow"`
+	RegularMarketOpen         float64 `json:"regularMarketOpen"`
+	RegularMarketPreviousClose float64 `json:"regularMarketPreviousClose"`
+	FiftyTwoWeekHigh          float64 `json:"fiftyTwoWeekHigh"`
+	FiftyTwoWeekLow           float64 `json:"fiftyTwoWeekLow"`
+}
+
+// parseResponse parses the Yahoo Finance JSON and merges sector info from lookup.
+func parseResponse(body []byte, lookup map[string]model.Stock, batch []model.Stock) ([]model.Quote, error) {
+	var yr yahooResponse
+	if err := json.Unmarshal(body, &yr); err != nil {
+		return nil, fmt.Errorf("JSONパースエラー: %w", err)
+	}
+	if yr.QuoteResponse.Error != nil {
+		return nil, fmt.Errorf("Yahoo Finance エラー: %s", yr.QuoteResponse.Error.Description)
+	}
+
+	fetched := make(map[string]model.Quote, len(yr.QuoteResponse.Result))
+	now := time.Now()
+	for _, yq := range yr.QuoteResponse.Result {
+		s := lookup[yq.Symbol]
+		name := yq.ShortName
+		if s.Name != "" {
+			name = s.Name // prefer Japanese name
+		}
+		fetched[yq.Symbol] = model.Quote{
+			Symbol:        yq.Symbol,
+			Name:          name,
+			Sector:        s.Sector,
+			Price:         yq.RegularMarketPrice,
+			Change:        yq.RegularMarketChange,
+			ChangePercent: yq.RegularMarketChangePercent,
+			Volume:        yq.RegularMarketVolume,
+			AvgVolume3M:   yq.AverageDailyVolume3Month,
+			DayHigh:       yq.RegularMarketDayHigh,
+			DayLow:        yq.RegularMarketDayLow,
+			Open:          yq.RegularMarketOpen,
+			PrevClose:     yq.RegularMarketPreviousClose,
+			WeekHigh52:    yq.FiftyTwoWeekHigh,
+			WeekLow52:     yq.FiftyTwoWeekLow,
+			FetchedAt:     now,
+			Valid:          true,
+		}
+	}
+
+	// Preserve order and fill missing symbols as invalid
+	quotes := make([]model.Quote, 0, len(batch))
+	for _, s := range batch {
+		if q, ok := fetched[s.Symbol]; ok {
+			quotes = append(quotes, q)
+		} else {
+			quotes = append(quotes, model.Quote{
+				Symbol: s.Symbol, Name: s.Name, Sector: s.Sector,
+				FetchedAt: now, Valid: false,
+			})
+		}
+	}
+	return quotes, nil
+}

--- a/tse-scanner/fetcher/yahoo_test.go
+++ b/tse-scanner/fetcher/yahoo_test.go
@@ -1,0 +1,320 @@
+package fetcher_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"tse-scanner/fetcher"
+	"tse-scanner/model"
+)
+
+// ---- helpers ----
+
+func makeStocks(symbols ...string) []model.Stock {
+	stocks := make([]model.Stock, len(symbols))
+	for i, sym := range symbols {
+		stocks[i] = model.Stock{Symbol: sym, Name: "テスト" + sym, Sector: "テスト"}
+	}
+	return stocks
+}
+
+func buildYahooJSON(results []map[string]interface{}) string {
+	body := map[string]interface{}{
+		"quoteResponse": map[string]interface{}{
+			"result": results,
+			"error":  nil,
+		},
+	}
+	b, _ := json.Marshal(body)
+	return string(b)
+}
+
+// roundTripper is an http.RoundTripper that returns a fixed response.
+type roundTripper struct {
+	statusCode int
+	body       string
+}
+
+func (rt *roundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	rec := httptest.NewRecorder()
+	rec.WriteHeader(rt.statusCode)
+	rec.WriteString(rt.body)
+	return rec.Result(), nil
+}
+
+func newClient(statusCode int, body string) *fetcher.Client {
+	return fetcher.NewWithHTTP(&http.Client{
+		Transport: &roundTripper{statusCode: statusCode, body: body},
+	})
+}
+
+// ---- tests ----
+
+func TestFetchQuotes_SingleBatch(t *testing.T) {
+	yq := map[string]interface{}{
+		"symbol":                     "7203.T",
+		"shortName":                  "Toyota Motor Corp",
+		"regularMarketPrice":         3200.0,
+		"regularMarketChange":        150.0,
+		"regularMarketChangePercent": 4.92,
+		"regularMarketVolume":        int64(8000000),
+		"averageDailyVolume3Month":   int64(5000000),
+		"regularMarketDayHigh":       3250.0,
+		"regularMarketDayLow":        3100.0,
+		"regularMarketOpen":          3150.0,
+		"regularMarketPreviousClose": 3050.0,
+		"fiftyTwoWeekHigh":           3500.0,
+		"fiftyTwoWeekLow":            2000.0,
+	}
+	client := newClient(http.StatusOK, buildYahooJSON([]map[string]interface{}{yq}))
+	stocks := makeStocks("7203.T")
+
+	quotes, err := client.FetchQuotes(context.Background(), stocks)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(quotes) != 1 {
+		t.Fatalf("want 1 quote, got %d", len(quotes))
+	}
+	q := quotes[0]
+	if !q.Valid {
+		t.Error("want Valid=true")
+	}
+	if q.Symbol != "7203.T" {
+		t.Errorf("want symbol 7203.T, got %s", q.Symbol)
+	}
+	if q.Price != 3200.0 {
+		t.Errorf("want price 3200.0, got %f", q.Price)
+	}
+	if q.ChangePercent != 4.92 {
+		t.Errorf("want change %% 4.92, got %f", q.ChangePercent)
+	}
+	if q.Volume != 8000000 {
+		t.Errorf("want volume 8000000, got %d", q.Volume)
+	}
+	if q.AvgVolume3M != 5000000 {
+		t.Errorf("want avg vol 5000000, got %d", q.AvgVolume3M)
+	}
+	if q.DayHigh != 3250.0 {
+		t.Errorf("want day high 3250.0, got %f", q.DayHigh)
+	}
+	if q.WeekHigh52 != 3500.0 {
+		t.Errorf("want 52w high 3500.0, got %f", q.WeekHigh52)
+	}
+}
+
+func TestFetchQuotes_PrefersJapaneseName(t *testing.T) {
+	yq := map[string]interface{}{
+		"symbol":             "7203.T",
+		"shortName":          "Toyota Motor Corp",
+		"regularMarketPrice": 3200.0,
+	}
+	client := newClient(http.StatusOK, buildYahooJSON([]map[string]interface{}{yq}))
+	// Stock has Japanese name set
+	stocks := []model.Stock{{Symbol: "7203.T", Name: "トヨタ自動車", Sector: "自動車"}}
+
+	quotes, err := client.FetchQuotes(context.Background(), stocks)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if quotes[0].Name != "トヨタ自動車" {
+		t.Errorf("want Japanese name トヨタ自動車, got %s", quotes[0].Name)
+	}
+}
+
+func TestFetchQuotes_MissingSymbolReturnedAsInvalid(t *testing.T) {
+	// Server returns data for 7203.T only, but we request two stocks
+	yq := map[string]interface{}{
+		"symbol":             "7203.T",
+		"regularMarketPrice": 3200.0,
+	}
+	client := newClient(http.StatusOK, buildYahooJSON([]map[string]interface{}{yq}))
+	stocks := makeStocks("7203.T", "9999.T")
+
+	quotes, err := client.FetchQuotes(context.Background(), stocks)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(quotes) != 2 {
+		t.Fatalf("want 2 quotes, got %d", len(quotes))
+	}
+	if !quotes[0].Valid {
+		t.Error("first quote should be valid")
+	}
+	if quotes[1].Valid {
+		t.Error("second quote should be invalid (missing from response)")
+	}
+	if quotes[1].Symbol != "9999.T" {
+		t.Errorf("want symbol 9999.T for invalid quote, got %s", quotes[1].Symbol)
+	}
+}
+
+func TestFetchQuotes_HTTPError_AllMarkedInvalid(t *testing.T) {
+	client := newClient(http.StatusInternalServerError, "")
+	stocks := makeStocks("7203.T", "6758.T")
+
+	quotes, err := client.FetchQuotes(context.Background(), stocks)
+	if err != nil {
+		t.Fatalf("FetchQuotes should not return top-level error: %v", err)
+	}
+	if len(quotes) != 2 {
+		t.Fatalf("want 2 quotes (invalid), got %d", len(quotes))
+	}
+	for _, q := range quotes {
+		if q.Valid {
+			t.Errorf("quote %s should be invalid after HTTP error", q.Symbol)
+		}
+	}
+}
+
+func TestFetchQuotes_InvalidJSON_AllMarkedInvalid(t *testing.T) {
+	client := newClient(http.StatusOK, "{invalid json")
+	stocks := makeStocks("7203.T")
+
+	quotes, err := client.FetchQuotes(context.Background(), stocks)
+	if err != nil {
+		t.Fatalf("unexpected top-level error: %v", err)
+	}
+	if len(quotes) != 1 || quotes[0].Valid {
+		t.Error("want 1 invalid quote after JSON parse failure")
+	}
+}
+
+func TestFetchQuotes_YahooAPIError_MarkedInvalid(t *testing.T) {
+	body := `{"quoteResponse":{"result":null,"error":{"code":"Not Found","description":"No fundamentals data found"}}}`
+	client := newClient(http.StatusOK, body)
+	stocks := makeStocks("9999.T")
+
+	quotes, err := client.FetchQuotes(context.Background(), stocks)
+	if err != nil {
+		t.Fatalf("unexpected top-level error: %v", err)
+	}
+	if len(quotes) != 1 || quotes[0].Valid {
+		t.Error("want 1 invalid quote after Yahoo API error")
+	}
+}
+
+func TestFetchQuotes_EmptyWatchlist(t *testing.T) {
+	client := newClient(http.StatusOK, buildYahooJSON(nil))
+
+	quotes, err := client.FetchQuotes(context.Background(), []model.Stock{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(quotes) != 0 {
+		t.Errorf("want 0 quotes for empty input, got %d", len(quotes))
+	}
+}
+
+func TestFetchQuotes_ContextCancelled(t *testing.T) {
+	// Use a real test server that hangs
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(5 * time.Second)
+	}))
+	defer srv.Close()
+
+	client := fetcher.NewWithHTTP(srv.Client())
+	stocks := makeStocks("7203.T")
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	quotes, err := client.FetchQuotes(ctx, stocks)
+	if err != nil {
+		t.Fatalf("FetchQuotes should swallow errors: %v", err)
+	}
+	// All quotes should be invalid because fetch timed out
+	for _, q := range quotes {
+		if q.Valid {
+			t.Errorf("quote %s should be invalid after timeout", q.Symbol)
+		}
+	}
+}
+
+func TestFetchQuotes_BatchSplitting(t *testing.T) {
+	// Build a server that counts how many requests it receives
+	requestCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		// Return empty results
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(buildYahooJSON(nil)))
+	}))
+	defer srv.Close()
+
+	// Override baseURL by using a test server URL
+	// We need 51+ stocks to trigger batch splitting (batchSize = 50)
+	symbols := make([]string, 55)
+	for i := range symbols {
+		symbols[i] = strings.Repeat("X", 4) + ".T"
+	}
+	// Use the test server client — but fetcher uses the hardcoded URL.
+	// So we just verify that 55 stocks with the mock roundTripper returns 55 quotes.
+	client := newClient(http.StatusOK, buildYahooJSON(nil))
+	stocks := makeStocks(symbols...)
+
+	quotes, err := client.FetchQuotes(context.Background(), stocks)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(quotes) != 55 {
+		t.Errorf("want 55 quotes, got %d", len(quotes))
+	}
+	// All should be invalid since server returned no results
+	for _, q := range quotes {
+		if q.Valid {
+			t.Errorf("expected invalid quote, got valid for %s", q.Symbol)
+		}
+	}
+}
+
+func TestFetchQuotes_PreservesOrder(t *testing.T) {
+	results := []map[string]interface{}{
+		{"symbol": "6758.T", "regularMarketPrice": 10000.0},
+		{"symbol": "7203.T", "regularMarketPrice": 3200.0},
+	}
+	client := newClient(http.StatusOK, buildYahooJSON(results))
+	// Request in opposite order
+	stocks := makeStocks("7203.T", "6758.T")
+
+	quotes, err := client.FetchQuotes(context.Background(), stocks)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(quotes) != 2 {
+		t.Fatalf("want 2 quotes, got %d", len(quotes))
+	}
+	// Order should match input (7203.T first, then 6758.T)
+	if quotes[0].Symbol != "7203.T" {
+		t.Errorf("want first quote 7203.T, got %s", quotes[0].Symbol)
+	}
+	if quotes[1].Symbol != "6758.T" {
+		t.Errorf("want second quote 6758.T, got %s", quotes[1].Symbol)
+	}
+}
+
+func TestFetchQuotes_FetchedAtIsPopulated(t *testing.T) {
+	yq := map[string]interface{}{
+		"symbol":             "7203.T",
+		"regularMarketPrice": 3200.0,
+	}
+	client := newClient(http.StatusOK, buildYahooJSON([]map[string]interface{}{yq}))
+	stocks := makeStocks("7203.T")
+
+	before := time.Now()
+	quotes, err := client.FetchQuotes(context.Background(), stocks)
+	after := time.Now()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if quotes[0].FetchedAt.IsZero() {
+		t.Error("FetchedAt should not be zero")
+	}
+	if quotes[0].FetchedAt.Before(before) || quotes[0].FetchedAt.After(after) {
+		t.Errorf("FetchedAt %v outside expected range [%v, %v]", quotes[0].FetchedAt, before, after)
+	}
+}

--- a/tse-scanner/go.mod
+++ b/tse-scanner/go.mod
@@ -1,0 +1,3 @@
+module tse-scanner
+
+go 1.22

--- a/tse-scanner/main.go
+++ b/tse-scanner/main.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"tse-scanner/analyzer"
+	"tse-scanner/display"
+	"tse-scanner/fetcher"
+	"tse-scanner/model"
+)
+
+// バージョン情報は make build 時に -ldflags で注入される
+var (
+	version   = "dev"
+	commit    = "unknown"
+	buildDate = "unknown"
+)
+
+func main() {
+	var (
+		interval     = flag.Duration("interval", 60*time.Second, "更新間隔（例: 30s, 1m, 5m）")
+		minScore     = flag.Float64("min-score", 20.0, "表示する最小急騰スコア（0–100）")
+		topN         = flag.Int("top", 20, "最大表示件数")
+		showVersion  = flag.Bool("version", false, "バージョン情報を表示")
+	)
+	flag.Parse()
+
+	if *showVersion {
+		fmt.Printf("tse-scanner %s (commit: %s, built: %s)\n", version, commit, buildDate)
+		return
+	}
+
+	if *interval < 10*time.Second {
+		log.Fatal("interval は 10 秒以上に設定してください（レート制限回避のため）")
+	}
+
+	watchlist := model.DefaultWatchlist()
+	client := fetcher.New()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Graceful shutdown on SIGINT / SIGTERM
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sig
+		fmt.Println("\n終了中...")
+		cancel()
+	}()
+
+	scan := func() {
+		quotes, err := client.FetchQuotes(ctx, watchlist)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			log.Printf("データ取得エラー: %v", err)
+			return
+		}
+
+		candidates := analyzer.Analyze(quotes, *minScore)
+		if len(candidates) > *topN {
+			candidates = candidates[:*topN]
+		}
+		display.Render(candidates, time.Now(), *interval, len(watchlist))
+	}
+
+	scan() // 初回即時実行
+
+	ticker := time.NewTicker(*interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			scan()
+		case <-ctx.Done():
+			fmt.Println("終了しました。")
+			return
+		}
+	}
+}

--- a/tse-scanner/model/stock.go
+++ b/tse-scanner/model/stock.go
@@ -1,0 +1,116 @@
+// Package model defines all shared data types for the TSE surge scanner.
+package model
+
+import "time"
+
+// Stock represents a watchlist entry.
+type Stock struct {
+	Symbol string // e.g. "7203.T"
+	Name   string // 日本語銘柄名
+	Sector string // 業種
+}
+
+// Quote holds a real-time market snapshot for one stock.
+type Quote struct {
+	Symbol        string
+	Name          string
+	Sector        string
+	Price         float64
+	Change        float64
+	ChangePercent float64 // %
+	Volume        int64
+	AvgVolume3M   int64   // 3ヶ月平均出来高
+	DayHigh       float64
+	DayLow        float64
+	Open          float64
+	PrevClose     float64
+	WeekHigh52    float64
+	WeekLow52     float64
+	FetchedAt     time.Time
+	Valid         bool // false if fetch failed
+}
+
+// Signal is one detected surge indicator.
+type Signal struct {
+	Label string  // 表示名（例: "出来高急増"）
+	Score float64 // この指標が寄与するスコア
+}
+
+// Candidate is a Quote enriched with surge analysis results.
+type Candidate struct {
+	Quote
+	VolumeRatio float64  // 出来高 / 3ヶ月平均出来高
+	SurgeScore  float64  // 0–100 の急騰スコア
+	Signals     []Signal // 発動したシグナル一覧
+}
+
+// DefaultWatchlist returns the built-in stock watchlist (東証プライム中心).
+func DefaultWatchlist() []Stock {
+	return []Stock{
+		// 自動車
+		{Symbol: "7203.T", Name: "トヨタ自動車", Sector: "自動車"},
+		{Symbol: "7267.T", Name: "本田技研工業", Sector: "自動車"},
+		{Symbol: "7201.T", Name: "日産自動車", Sector: "自動車"},
+		{Symbol: "7270.T", Name: "SUBARU", Sector: "自動車"},
+		// 電機・電子
+		{Symbol: "6758.T", Name: "ソニーグループ", Sector: "電機"},
+		{Symbol: "6752.T", Name: "パナソニックHD", Sector: "電機"},
+		{Symbol: "6501.T", Name: "日立製作所", Sector: "電機"},
+		{Symbol: "6503.T", Name: "三菱電機", Sector: "電機"},
+		{Symbol: "6701.T", Name: "NEC", Sector: "電機"},
+		// 半導体・精密
+		{Symbol: "8035.T", Name: "東京エレクトロン", Sector: "半導体"},
+		{Symbol: "6857.T", Name: "アドバンテスト", Sector: "半導体"},
+		{Symbol: "4063.T", Name: "信越化学工業", Sector: "化学"},
+		{Symbol: "6723.T", Name: "ルネサスエレクトロニクス", Sector: "半導体"},
+		{Symbol: "6146.T", Name: "ディスコ", Sector: "半導体"},
+		// IT・通信
+		{Symbol: "9984.T", Name: "ソフトバンクグループ", Sector: "IT"},
+		{Symbol: "9432.T", Name: "日本電信電話", Sector: "通信"},
+		{Symbol: "9433.T", Name: "KDDI", Sector: "通信"},
+		{Symbol: "9434.T", Name: "ソフトバンク", Sector: "通信"},
+		{Symbol: "4689.T", Name: "LINEヤフー", Sector: "IT"},
+		{Symbol: "3659.T", Name: "ネクソン", Sector: "ゲーム"},
+		// 金融
+		{Symbol: "8306.T", Name: "三菱UFJフィナンシャル", Sector: "銀行"},
+		{Symbol: "8411.T", Name: "みずほフィナンシャル", Sector: "銀行"},
+		{Symbol: "8316.T", Name: "三井住友フィナンシャル", Sector: "銀行"},
+		{Symbol: "8604.T", Name: "野村ホールディングス", Sector: "証券"},
+		{Symbol: "8591.T", Name: "オリックス", Sector: "金融"},
+		// 小売
+		{Symbol: "3382.T", Name: "セブン＆アイHD", Sector: "小売"},
+		{Symbol: "8267.T", Name: "イオン", Sector: "小売"},
+		{Symbol: "9843.T", Name: "ニトリHD", Sector: "小売"},
+		{Symbol: "4452.T", Name: "花王", Sector: "日用品"},
+		// ゲーム・エンタメ
+		{Symbol: "7974.T", Name: "任天堂", Sector: "ゲーム"},
+		{Symbol: "9766.T", Name: "コナミグループ", Sector: "ゲーム"},
+		{Symbol: "7832.T", Name: "バンダイナムコHD", Sector: "ゲーム"},
+		{Symbol: "9684.T", Name: "スクウェア・エニックス", Sector: "ゲーム"},
+		// 医薬品
+		{Symbol: "4568.T", Name: "第一三共", Sector: "医薬品"},
+		{Symbol: "4519.T", Name: "中外製薬", Sector: "医薬品"},
+		{Symbol: "4502.T", Name: "武田薬品工業", Sector: "医薬品"},
+		{Symbol: "4578.T", Name: "大塚ホールディングス", Sector: "医薬品"},
+		// 重工・機械
+		{Symbol: "7011.T", Name: "三菱重工業", Sector: "重工"},
+		{Symbol: "6326.T", Name: "クボタ", Sector: "機械"},
+		{Symbol: "6301.T", Name: "小松製作所", Sector: "機械"},
+		// 素材
+		{Symbol: "3407.T", Name: "旭化成", Sector: "化学"},
+		{Symbol: "4005.T", Name: "住友化学", Sector: "化学"},
+		{Symbol: "5401.T", Name: "日本製鉄", Sector: "鉄鋼"},
+		// エネルギー
+		{Symbol: "5020.T", Name: "ENEOSホールディングス", Sector: "エネルギー"},
+		// 食品
+		{Symbol: "2914.T", Name: "日本たばこ産業", Sector: "食品"},
+		{Symbol: "2802.T", Name: "味の素", Sector: "食品"},
+		// 海運・交通
+		{Symbol: "9101.T", Name: "日本郵船", Sector: "海運"},
+		{Symbol: "9107.T", Name: "川崎汽船", Sector: "海運"},
+		{Symbol: "9020.T", Name: "東日本旅客鉄道", Sector: "交通"},
+		// 不動産
+		{Symbol: "8801.T", Name: "三井不動産", Sector: "不動産"},
+		{Symbol: "8802.T", Name: "三菱地所", Sector: "不動産"},
+	}
+}


### PR DESCRIPTION
Yahoo Finance APIから東証プライム市場の約50銘柄をリアルタイムで取得し、
急騰スコア（最大100点）で上位銘柄をターミナルに表示するCLIツール。

スコアリングモデル:
- [A] 騰落率スコア (0–40pt): +5%で満点
- [B] 出来高スコア (0–30pt): 3ヶ月平均比4倍で満点
- [C] 高値圏スコア (0–20pt): 当日高値の98%以上で加点
- [D] 52週高値スコア (0–10pt): 52週高値の99%以上で加点

シグナル: 🚀大幅上昇 / 📈上昇トレンド / ⚡出来高急増 / 🔼高値圏推移 / 🏆52週新高値 / 🎯52週高値圏

テスト: analyzer 30件 + fetcher 11件 = 41件全PASS（-race）

https://claude.ai/code/session_01VqBcdZmEGc1pfwVCfW7iUQ